### PR TITLE
fix: auth and token refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,13 +402,14 @@ In this example, we show how to use the bearer token using the Openbridge API ke
       "command": "npx",
       "args": [
         "-y",
-        "--allow-http",
-        "mcp-remote",
+        "mcp-remote@latest",
         "http://${HOSTNAME}:${PORT}/mcp/",
+        "--allow-http",
         "--header",
-        "Authorization: Bearer ${OPENBRIDGE_REFRESH_TOKEN}",
+        "Authorization:Bearer ${OPENBRIDGE_REFRESH_TOKEN}",
         "--header",
-        "Accept: application/json, text/event-stream"
+        "Accept:application/json,text/event-stream",
+        "--debug"
       ],
       "env": {
         "MCP_TIMEOUT": "300",
@@ -440,9 +441,9 @@ The config would look something like this:
       "command": "npx",
       "args": [
         "-y",
-        "--allow-http",
         "mcp-remote",
         "http://${HOSTNAME}:${PORT}/mcp/",
+        "--allow-http",
         "--header",
         "Authorization:${AUTH_HEADER}"
         "--header",
@@ -475,7 +476,8 @@ Here is another example, which can be used if you are using OAuth since the `OPE
       "args": [
         "-y",
         "mcp-remote@latest",
-        "http://localhost:9080/mcp"
+        "http://localhost:9080/mcp/",
+        "--allow-http"
       ],
       "env": {
         "MCP_TIMEOUT""120000",
@@ -489,6 +491,8 @@ Here is another example, which can be used if you are using OAuth since the `OPE
   }
 }
 ```
+
+*Note: For various Claude configurations similar to what was shown above, see the [MCP Remote docs](https://github.com/geelen/mcp-remote) for the latest settings/options.*
 
 ### 3. Restart Claude Desktop
 

--- a/src/amazon_ads_mcp/auth/token_store.py
+++ b/src/amazon_ads_mcp/auth/token_store.py
@@ -534,7 +534,8 @@ class PersistentTokenStore(InMemoryTokenStore):
 
             # Generate and persist a strong random key
             # This ensures we always use strong encryption, never weak deterministic keys
-            key_file = self._cache_dir / ".encryption.key"
+            # Use the parent directory of storage_path for the encryption key
+            key_file = self._storage_path.parent / ".encryption.key"
 
             # Check if we're in production-like environment
             is_production = (


### PR DESCRIPTION
This ensures the encryption key is stored in the same directory as the token file, which is the correct location