### PR TITLE
fix: security and correctness top5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,25 @@ export AMAZON_ADS_DOWNLOAD_ALLOWED_EXTENSIONS=".json,.csv,.txt,.gz"
 export AMAZON_ADS_DOWNLOAD_DIR="./data"
 ```
 
+### Public URL Resolution
+
+```bash
+# Canonical external URL of this server. When set, all public links
+# (download URLs, OAuth redirect_uri fallbacks) use this value. Required
+# for any deployment behind a proxy or load balancer.
+export AMAZON_ADS_PUBLIC_BASE_URL="https://ads.example.com"
+
+# Only honor X-Forwarded-Proto / X-Forwarded-Host from the client when
+# explicitly enabled. Do NOT enable on a directly internet-exposed server:
+# a malicious client can otherwise forge public URLs pointing at their
+# own domain.
+export AMAZON_ADS_TRUST_FORWARDED_HEADERS="false"
+
+# OAuth redirect URI (required for non-localhost deployments). Must match
+# the value registered with Amazon Ads.
+export OAUTH_REDIRECT_URI="https://ads.example.com/auth/callback"
+```
+
 ### Security-Related Environment Variables
 
 ```bash

--- a/src/amazon_ads_mcp/auth/manager.py
+++ b/src/amazon_ads_mcp/auth/manager.py
@@ -12,6 +12,7 @@ The module supports:
 - Region-specific endpoint handling
 """
 
+import asyncio
 import logging
 import os
 from datetime import datetime, timedelta, timezone
@@ -113,8 +114,32 @@ class AuthManager:
         # the token is still valid.
         self._credentials_cache: Dict[str, "AuthCredentials"] = {}
 
+        # Per-identity asyncio locks used to coalesce concurrent
+        # credential refreshes (single-flight).  ``_refresh_locks_lock``
+        # guards lazy creation of the per-identity locks so two tasks
+        # racing into the first request for the same identity cannot
+        # create two different Lock objects.
+        self._identity_refresh_locks: Dict[str, asyncio.Lock] = {}
+        self._refresh_locks_lock: Optional[asyncio.Lock] = None
+
         # Initialize provider based on settings
         self._setup_provider()
+
+    async def _get_refresh_lock(self, identity_id: str) -> asyncio.Lock:
+        """Return the asyncio.Lock that serializes refreshes for *identity_id*.
+
+        The outer ``_refresh_locks_lock`` is created lazily because
+        :class:`asyncio.Lock` must be constructed inside a running loop
+        on some Python versions.
+        """
+        if self._refresh_locks_lock is None:
+            self._refresh_locks_lock = asyncio.Lock()
+        async with self._refresh_locks_lock:
+            lock = self._identity_refresh_locks.get(identity_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._identity_refresh_locks[identity_id] = lock
+            return lock
 
     def _setup_provider(self):
         """Setup authentication provider using the registry.
@@ -469,9 +494,11 @@ class AuthManager:
                     )
 
             identity_id = active_identity.id
-            logger.info(f"Getting credentials for active identity: {identity_id}")
+            logger.debug(
+                "Getting credentials for active identity: %s", identity_id
+            )
 
-            # Prefer in-memory credentials for active identity until just before expiry.
+            # Fast path: in-memory credentials still comfortably valid
             cached_creds = self._credentials_cache.get(identity_id)
             if cached_creds and cached_creds.identity_id == identity_id:
                 now = datetime.now(timezone.utc)
@@ -485,99 +512,110 @@ class AuthManager:
                         refresh_at,
                     )
                     return cached_creds
-                logger.info(
-                    "In-memory credentials for %s are near expiry, refreshing now",
+                logger.debug(
+                    "In-memory credentials for %s are near expiry, refreshing",
                     identity_id,
                 )
 
-            # Try to get cached credentials from token store
-            cached_access = await self.get_token(
-                provider_type=self.provider.provider_type,
-                identity_id=identity_id,
-                token_kind=TokenKind.ACCESS,
-                region=active_identity.attributes.get("region"),
-            )
-
-            if cached_access and not cached_access.is_expired():
-                # Check if provider requires identity-specific headers
-                if (
-                    hasattr(self.provider, "headers_are_identity_specific")
-                    and self.provider.headers_are_identity_specific()
-                ):
-                    # For identity-specific providers (e.g. Openbridge), the
-                    # full AuthCredentials are cached alongside the token so
-                    # we don't need to re-fetch from the remote service on
-                    # every tool call.
-                    cached_creds = self._credentials_cache.get(identity_id)
-                    if (
-                        cached_creds
-                        and cached_creds.access_token == cached_access.value
-                        and datetime.now(timezone.utc) < cached_creds.expires_at
-                    ):
-                        logger.info(
-                            f"Using cached full credentials for {identity_id}"
+            # Slow path: coalesce concurrent refreshes per identity so
+            # bursty tool calls trigger at most one provider fetch.
+            refresh_lock = await self._get_refresh_lock(identity_id)
+            async with refresh_lock:
+                # Re-check in-memory cache now that we hold the lock; a
+                # previous waiter may have already refreshed.
+                cached_creds = self._credentials_cache.get(identity_id)
+                if cached_creds and cached_creds.identity_id == identity_id:
+                    now = datetime.now(timezone.utc)
+                    refresh_at = cached_creds.expires_at - timedelta(
+                        seconds=self._CREDENTIAL_REFRESH_SKEW_SECONDS
+                    )
+                    if now < refresh_at:
+                        logger.debug(
+                            "Reusing credentials refreshed by another task for %s",
+                            identity_id,
                         )
-                        _ctx_set_credentials(cached_creds)
                         return cached_creds
-                    logger.info(
-                        f"{self.provider.provider_type}: Cached token valid but "
-                        f"full credentials not cached, fetching fresh"
+
+                # Re-check token store cache as well
+                cached_access = await self.get_token(
+                    provider_type=self.provider.provider_type,
+                    identity_id=identity_id,
+                    token_kind=TokenKind.ACCESS,
+                    region=active_identity.attributes.get("region"),
+                )
+
+                if cached_access and not cached_access.is_expired():
+                    if (
+                        hasattr(self.provider, "headers_are_identity_specific")
+                        and self.provider.headers_are_identity_specific()
+                    ):
+                        cached_creds = self._credentials_cache.get(identity_id)
+                        if (
+                            cached_creds
+                            and cached_creds.access_token == cached_access.value
+                            and datetime.now(timezone.utc) < cached_creds.expires_at
+                        ):
+                            logger.debug(
+                                "Using cached full credentials for %s",
+                                identity_id,
+                            )
+                            _ctx_set_credentials(cached_creds)
+                            return cached_creds
+                        logger.debug(
+                            "%s: cached token valid but full credentials not cached, fetching fresh",
+                            self.provider.provider_type,
+                        )
+                    else:
+                        creds = AuthCredentials(
+                            identity_id=identity_id,
+                            access_token=cached_access.value,
+                            expires_at=cached_access.expires_at,
+                            base_url=(
+                                self.provider.get_region_endpoint()
+                                if hasattr(self.provider, "get_region_endpoint")
+                                else None
+                            ),
+                            headers=(
+                                await self.provider.get_headers()
+                                if hasattr(self.provider, "get_headers")
+                                else {}
+                            ),
+                        )
+                        _ctx_set_credentials(creds)
+                        return creds
+                elif cached_access:
+                    logger.debug(
+                        "Credentials for %s expired, refreshing", identity_id
                     )
-                    # Fall through to fetch fresh credentials
-                else:
-                    # Reconstruct credentials from cached token (for providers without identity-specific headers)
-                    creds = AuthCredentials(
-                        identity_id=identity_id,
-                        access_token=cached_access.value,
-                        expires_at=cached_access.expires_at,
-                        base_url=(
-                            self.provider.get_region_endpoint()
-                            if hasattr(self.provider, "get_region_endpoint")
-                            else None
-                        ),
-                        headers=(
-                            await self.provider.get_headers()
-                            if hasattr(self.provider, "get_headers")
-                            else {}
-                        ),
-                    )
-                    _ctx_set_credentials(creds)
-                    return creds
-            elif cached_access:
-                logger.info(f"Credentials for {identity_id} expired, refreshing")
 
-            # Get new credentials
-            logger.info(
-                f"Fetching fresh credentials from {self.provider.provider_type} for identity {identity_id}"
-            )
-            credentials = await self.provider.get_identity_credentials(identity_id)
-            logger.info(
-                f"Got credentials with headers: {list(credentials.headers.keys())}"
-            )
-            logger.info(
-                f"Client ID in credentials: {credentials.headers.get('Amazon-Advertising-API-ClientId')}"
-            )
+                logger.debug(
+                    "Fetching fresh credentials from %s for identity %s",
+                    self.provider.provider_type,
+                    identity_id,
+                )
+                credentials = await self.provider.get_identity_credentials(
+                    identity_id
+                )
 
-            # Store access token in unified store
-            await self.set_token(
-                provider_type=self.provider.provider_type,
-                identity_id=identity_id,
-                token_kind=TokenKind.ACCESS,
-                token=credentials.access_token,
-                expires_at=credentials.expires_at,
-                metadata={"base_url": credentials.base_url},
-                region=active_identity.attributes.get("region"),
-            )
+                await self.set_token(
+                    provider_type=self.provider.provider_type,
+                    identity_id=identity_id,
+                    token_kind=TokenKind.ACCESS,
+                    token=credentials.access_token,
+                    expires_at=credentials.expires_at,
+                    metadata={"base_url": credentials.base_url},
+                    region=active_identity.attributes.get("region"),
+                )
 
-            # Cache full credentials for identity-specific providers
-            self._credentials_cache[identity_id] = credentials
+                self._credentials_cache[identity_id] = credentials
+                _ctx_set_credentials(credentials)
 
-            _ctx_set_credentials(credentials)
-
-            logger.info(
-                f"Got credentials for {identity_id}, expires at {credentials.expires_at}"
-            )
-            return credentials
+                logger.debug(
+                    "Got credentials for %s, expires at %s",
+                    identity_id,
+                    credentials.expires_at,
+                )
+                return credentials
 
         # For single-identity providers, create synthetic credentials
         else:

--- a/src/amazon_ads_mcp/auth/oauth_state_store.py
+++ b/src/amazon_ads_mcp/auth/oauth_state_store.py
@@ -89,11 +89,14 @@ class OAuthStateStore:
         state_base = secrets.token_urlsafe(32)
         nonce = secrets.token_hex(16)
 
-        # Create HMAC signature
+        # Create HMAC signature. Use the full SHA-256 hex digest (64 hex
+        # chars / 256 bits) rather than a 64-bit prefix: the state token is
+        # only ever sent back to us and the few extra bytes matter much
+        # less than making brute-force forgery infeasible.
         message = f"{state_base}:{nonce}:{auth_url}"
         signature = hmac.new(
             self.secret_key.encode(), message.encode(), hashlib.sha256
-        ).hexdigest()[:16]  # Use first 16 chars for brevity
+        ).hexdigest()
 
         # Combine into final state
         state = f"{state_base}.{signature}"
@@ -155,7 +158,7 @@ class OAuthStateStore:
             message = f"{state_base}:{entry.nonce}:{entry.auth_url}"
             expected_signature = hmac.new(
                 self.secret_key.encode(), message.encode(), hashlib.sha256
-            ).hexdigest()[:16]
+            ).hexdigest()
 
             if not hmac.compare_digest(signature, expected_signature):
                 logger.warning("Invalid OAuth state signature")

--- a/src/amazon_ads_mcp/auth/providers/direct.py
+++ b/src/amazon_ads_mcp/auth/providers/direct.py
@@ -4,6 +4,7 @@ This module implements direct authentication using Amazon Ads API credentials,
 if you are using your own Amazon Ads API credentials/app.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
@@ -51,6 +52,9 @@ class DirectAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         self.profile_id = config.get("profile_id")
         self._region = config.get("region", "na")
         self._access_token: Optional[Token] = None
+        # Serializes concurrent refresh token -> access token exchanges
+        # so that N in-flight tool calls do not trigger N OAuth2 requests.
+        self._refresh_lock: Optional[asyncio.Lock] = None
 
     @property
     def provider_type(self) -> str:
@@ -150,11 +154,24 @@ class DirectAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         Performs OAuth2 token refresh to obtain a new access token
         from Amazon's authentication servers.
 
+        Concurrent callers are coalesced via an ``asyncio.Lock`` so only
+        one OAuth2 exchange runs at a time; waiters re-use the cached
+        token set by the first winner.
+
         :return: New access token with expiration
         :rtype: Token
         :raises ValueError: If no refresh token is available or token response is invalid
         :raises httpx.HTTPError: If the OAuth2 token request fails
         """
+        if self._refresh_lock is None:
+            self._refresh_lock = asyncio.Lock()
+        async with self._refresh_lock:
+            # Inside the lock, see if another task already refreshed.
+            if self._access_token and await self.validate_token(self._access_token):
+                return self._access_token
+            return await self._refresh_access_token_locked()
+
+    async def _refresh_access_token_locked(self) -> Token:
         # Check if refresh token is available from secure store
         if not self.refresh_token:
             try:

--- a/src/amazon_ads_mcp/auth/providers/openbridge.py
+++ b/src/amazon_ads_mcp/auth/providers/openbridge.py
@@ -5,6 +5,7 @@ which manages multiple Amazon Ads identities through OpenBridge's
 remote identity service.
 """
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -123,6 +124,20 @@ class OpenBridgeProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         self._identities_cache: Dict[tuple, List[Identity]] = {}
         # Max cache entries to prevent unbounded growth
         self._max_cache_entries = 32
+        # Per-fingerprint locks that serialize concurrent refresh-token ->
+        # JWT exchanges so bursty tool calls share a single network fetch.
+        self._refresh_locks: Dict[str, asyncio.Lock] = {}
+        self._refresh_locks_guard: Optional[asyncio.Lock] = None
+
+    async def _get_refresh_lock(self, fingerprint: str) -> asyncio.Lock:
+        if self._refresh_locks_guard is None:
+            self._refresh_locks_guard = asyncio.Lock()
+        async with self._refresh_locks_guard:
+            lock = self._refresh_locks.get(fingerprint)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._refresh_locks[fingerprint] = lock
+            return lock
 
     @property
     def provider_type(self) -> str:
@@ -197,11 +212,27 @@ class OpenBridgeProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         return await self._refresh_jwt_token()
 
     async def _refresh_jwt_token(self) -> Token:
-        """Convert refresh token to JWT via OpenBridge."""
+        """Convert refresh token to JWT via OpenBridge.
+
+        Concurrent callers for the same refresh token share a single
+        network fetch via a per-fingerprint ``asyncio.Lock``; waiters
+        return the freshly cached JWT.
+        """
         effective_token = self._get_effective_refresh_token()
         if not effective_token:
             raise ValueError("Cannot refresh JWT: No refresh token available")
 
+        fingerprint = self._token_fingerprint(effective_token)
+        lock = await self._get_refresh_lock(fingerprint)
+        async with lock:
+            cached = self._jwt_tokens.get(fingerprint)
+            if cached and await self.validate_token(cached):
+                return cached
+            return await self._refresh_jwt_token_locked(effective_token, fingerprint)
+
+    async def _refresh_jwt_token_locked(
+        self, effective_token: str, fingerprint: str
+    ) -> Token:
         logger.debug("Converting OpenBridge refresh token to JWT")
 
         client = await self._get_client()
@@ -242,8 +273,6 @@ class OpenBridgeProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
                 },
             )
 
-            # Store in fingerprinted cache with bounded eviction
-            fingerprint = self._token_fingerprint(effective_token)
             if len(self._jwt_tokens) >= self._max_cache_entries:
                 oldest_key = next(iter(self._jwt_tokens))
                 del self._jwt_tokens[oldest_key]

--- a/src/amazon_ads_mcp/auth/token_store.py
+++ b/src/amazon_ads_mcp/auth/token_store.py
@@ -27,6 +27,17 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+class TokenStoreDecryptError(RuntimeError):
+    """Raised when a persisted token store cannot be decrypted.
+
+    This is distinct from "file missing" or "file empty": it means the
+    on-disk ciphertext is present but cannot be decrypted with the
+    configured key. Silently returning ``{}`` would look identical to a
+    fresh install and would cause the server to quietly re-authenticate
+    every identity from scratch, which is a security-relevant surprise.
+    """
+
+
 class TokenKind(Enum):
     """Types of tokens stored in the system."""
 
@@ -436,6 +447,11 @@ class PersistentTokenStore(InMemoryTokenStore):
 
             logger.info(f"Loaded {len(self._store)} tokens from persistent storage")
 
+        except TokenStoreDecryptError:
+            # Let decryption failures surface: silently discarding the
+            # persisted store on a bad key would look identical to a fresh
+            # install and would force unexpected re-authentication.
+            raise
         except Exception as e:
             logger.error(f"Failed to load tokens from disk: {e}")
 
@@ -535,12 +551,31 @@ class PersistentTokenStore(InMemoryTokenStore):
                     logger.info("Using encryption key from AMAZON_ADS_ENCRYPTION_KEY")
                     return cipher
                 except Exception as e:
-                    logger.error(
-                        f"CRITICAL: Invalid AMAZON_ADS_ENCRYPTION_KEY: {e}\n"
-                        f"Previously encrypted tokens will be UNREADABLE!\n"
-                        f'Generate a valid key with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"\n'
-                        f"Falling back to auto-generated random key"
+                    # Hard fail when persistence is enabled: silently falling
+                    # back to an auto-generated key would (a) make previously
+                    # encrypted on-disk tokens unreadable and (b) make the
+                    # security posture depend on an invalid key being
+                    # configured, which is never what operators want.
+                    persist_enabled = (
+                        os.getenv("AMAZON_ADS_TOKEN_PERSIST", "false").lower()
+                        == "true"
                     )
+                    if persist_enabled:
+                        raise RuntimeError(
+                            "Invalid AMAZON_ADS_ENCRYPTION_KEY while "
+                            "AMAZON_ADS_TOKEN_PERSIST=true: refusing to start "
+                            "with a random fallback key that would make "
+                            "previously persisted tokens unreadable. "
+                            f"Underlying error: {e}"
+                        ) from e
+                    logger.error(
+                        "Invalid AMAZON_ADS_ENCRYPTION_KEY: %s. "
+                        "Persistence is disabled so encryption is also disabled "
+                        "for this session. Fix the key before enabling "
+                        "AMAZON_ADS_TOKEN_PERSIST=true.",
+                        e,
+                    )
+                    return None
 
             # Generate and persist a strong random key
             # This ensures we always use strong encryption, never weak deterministic keys
@@ -595,6 +630,11 @@ class PersistentTokenStore(InMemoryTokenStore):
 
             return cipher
 
+        except RuntimeError:
+            # Typed hard-fail paths (e.g. invalid AMAZON_ADS_ENCRYPTION_KEY
+            # while persistence is enabled) must propagate rather than
+            # silently disable encryption and fall back to plaintext.
+            raise
         except Exception as e:
             logger.error(f"Failed to initialize encryption: {e}")
             return None
@@ -666,8 +706,11 @@ class PersistentTokenStore(InMemoryTokenStore):
             return data
 
         if not self._cipher:
-            logger.error("Cannot decrypt data - encryption not available")
-            return {}
+            raise TokenStoreDecryptError(
+                "Persisted token store is encrypted but no cipher is "
+                "available to decrypt it. Configure AMAZON_ADS_ENCRYPTION_KEY "
+                "or remove the persisted store."
+            )
 
         try:
             # Extract and decode the encrypted data
@@ -680,9 +723,15 @@ class PersistentTokenStore(InMemoryTokenStore):
             # Parse the JSON
             return json.loads(decrypted_bytes.decode())
 
+        except TokenStoreDecryptError:
+            raise
         except Exception as e:
-            logger.error(f"Decryption failed: {e}")
-            return {}
+            raise TokenStoreDecryptError(
+                f"Failed to decrypt persisted token store: {e}. "
+                "The on-disk file may be corrupt or encrypted with a "
+                "different key. Move or remove the file to force a clean "
+                "start, or restore the original AMAZON_ADS_ENCRYPTION_KEY."
+            ) from e
 
 
 # Factory function for creating token stores

--- a/src/amazon_ads_mcp/config/settings.py
+++ b/src/amazon_ads_mcp/config/settings.py
@@ -253,6 +253,29 @@ class Settings(BaseSettings):
         description="Comma-separated list of allowed file extensions (e.g., '.json,.csv,.gz')",
     )
 
+    # Public URL resolution
+    public_base_url: Optional[str] = Field(
+        None,
+        alias="AMAZON_ADS_PUBLIC_BASE_URL",
+        description=(
+            "Absolute external URL of this server (e.g. 'https://ads.example.com'). "
+            "When set, all generated public links (downloads, OAuth callbacks) "
+            "use this value instead of attempting to infer it from request headers. "
+            "Required for any deployment where the server sits behind a proxy or "
+            "load balancer."
+        ),
+    )
+    trust_forwarded_headers: bool = Field(
+        False,
+        alias="AMAZON_ADS_TRUST_FORWARDED_HEADERS",
+        description=(
+            "If true, honor X-Forwarded-Proto / X-Forwarded-Host from the client. "
+            "Only enable this when the server is behind a proxy that strips or "
+            "rewrites these headers from untrusted callers. Enabling it on a "
+            "directly exposed server allows any client to forge public URLs."
+        ),
+    )
+
     @field_validator("auth_method")
     @classmethod
     def auto_detect_auth_method(cls, v: str, info) -> str:

--- a/src/amazon_ads_mcp/middleware/authentication.py
+++ b/src/amazon_ads_mcp/middleware/authentication.py
@@ -650,7 +650,18 @@ class RefreshTokenMiddleware(Middleware):
             # Let ToolError propagate - it's handled by FastMCP
             raise
         except Exception as e:
-            self.logger.error(f"RefreshTokenMiddleware error: {e}")
+            # Fail closed: if auth setup raises unexpectedly, do not silently
+            # pass the request through to downstream handlers with no
+            # identity attached. An operator error (e.g. misconfigured
+            # header parsing) previously produced an unauthenticated
+            # request, which could surface as "silent success" against
+            # the Amazon Ads API using a stale/default identity.
+            self.logger.error(
+                "RefreshTokenMiddleware error (failing closed): %s", e
+            )
+            raise ToolError(
+                "Authentication pre-processing failed; request rejected."
+            ) from e
 
         # Wrap call_next in try/finally to ensure ContextVar cleanup
         # even if the downstream handler raises an exception

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -555,12 +555,20 @@ Note: Requires HTTP transport (not stdio).
                 hint="Set active profile before getting download URLs",
             )
 
-        # Validate file exists
+        # Validate file exists and stays inside the active profile's dir
         from ..utils.export_download_handler import get_download_handler
+        from ..utils.paths import PathTraversalError, safe_join_within
 
         handler = get_download_handler()
         profile_dir = handler.base_dir / "profiles" / profile_id
-        full_path = profile_dir / file_path
+        try:
+            full_path = safe_join_within(profile_dir, file_path)
+        except PathTraversalError:
+            return GetDownloadUrlResponse(
+                success=False,
+                error="Invalid file path",
+                hint="Paths must be relative and stay within the active profile's directory",
+            )
 
         if not full_path.exists():
             return GetDownloadUrlResponse(

--- a/src/amazon_ads_mcp/server/file_routes.py
+++ b/src/amazon_ads_mcp/server/file_routes.py
@@ -553,30 +553,39 @@ async def _verify_download_auth(request: Request) -> Optional[JSONResponse]:
 
 
 def _get_base_url(request: Request) -> str:
-    """Get the correct base URL, respecting proxy headers.
+    """Get the correct base URL.
 
-    Handles X-Forwarded-Proto and X-Forwarded-Host from reverse proxies.
+    Resolution order:
 
-    Args:
-        request: Starlette request object
+    1. ``AMAZON_ADS_PUBLIC_BASE_URL`` (explicit, operator-controlled). This
+       is the only option that is safe on a directly internet-exposed
+       server: Host/X-Forwarded-* headers are client-controlled and can
+       otherwise be used to forge public download URLs pointing at an
+       attacker's domain.
+    2. ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` — only honored when
+       ``AMAZON_ADS_TRUST_FORWARDED_HEADERS=true`` is set explicitly by an
+       operator running behind a proxy that strips these headers from
+       untrusted callers.
+    3. Fallback to the raw ``request.base_url`` from the ASGI scope.
 
-    Returns:
-        Base URL string without trailing slash
+    :param request: Starlette request object
+    :returns: Base URL string without trailing slash
     """
-    forwarded_proto = request.headers.get("X-Forwarded-Proto")
-    forwarded_host = request.headers.get("X-Forwarded-Host")
+    from ..config.settings import Settings
 
-    if forwarded_proto and forwarded_host:
-        return f"{forwarded_proto}://{forwarded_host}"
+    settings = Settings()
 
-    # Fallback to request.base_url
-    base_url = str(request.base_url).rstrip("/")
+    public_base_url = getattr(settings, "public_base_url", None)
+    if public_base_url:
+        return public_base_url.rstrip("/")
 
-    # Fix common proxy misconfiguration
-    if forwarded_proto == "https" and base_url.startswith("http://"):
-        base_url = base_url.replace("http://", "https://", 1)
+    if getattr(settings, "trust_forwarded_headers", False):
+        forwarded_proto = request.headers.get("X-Forwarded-Proto")
+        forwarded_host = request.headers.get("X-Forwarded-Host")
+        if forwarded_proto and forwarded_host:
+            return f"{forwarded_proto}://{forwarded_host}"
 
-    return base_url
+    return str(request.base_url).rstrip("/")
 
 
 def _create_error_response(

--- a/src/amazon_ads_mcp/server/file_routes.py
+++ b/src/amazon_ads_mcp/server/file_routes.py
@@ -428,12 +428,18 @@ def _validate_file_access(file_path: Path, base_dir: Path) -> Optional[dict]:
     Returns:
         None if access allowed, error dict otherwise
     """
-    # 1. Path traversal prevention
+    # 1. Path traversal prevention (symlink-aware, shared with MCP tools)
+    from ..utils.paths import PathTraversalError, safe_join_within
+
     try:
-        resolved = file_path.resolve()
         base_resolved = base_dir.resolve()
-        resolved.relative_to(base_resolved)
-    except ValueError:
+        resolved = file_path.resolve()
+        # Re-validate containment via the shared helper using the relative
+        # form of the resolved path. If ``file_path`` was already resolved
+        # inside ``base_dir`` this is a no-op; otherwise the helper raises.
+        rel = resolved.relative_to(base_resolved)
+        safe_join_within(base_dir, str(rel))
+    except (ValueError, PathTraversalError):
         return {
             "error": "Access denied: path traversal detected",
             "error_code": "PATH_TRAVERSAL",

--- a/src/amazon_ads_mcp/server/server_builder.py
+++ b/src/amazon_ads_mcp/server/server_builder.py
@@ -934,12 +934,14 @@ class ServerBuilder:
         from starlette.requests import Request
         from starlette.responses import JSONResponse
 
+        from .. import __version__ as package_version
+
         @self.server.custom_route("/health", methods=["GET"])
         async def health_check(request: Request) -> JSONResponse:
             return JSONResponse(
                 {
                     "status": "healthy",
                     "service": "amazon-ads-mcp",
-                    "version": "1.0.0",
+                    "version": package_version,
                 }
             )

--- a/src/amazon_ads_mcp/tools/download_tools.py
+++ b/src/amazon_ads_mcp/tools/download_tools.py
@@ -10,7 +10,6 @@ unified interface for managing downloaded data files.
 
 import json
 import logging
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from ..utils.export_download_handler import get_download_handler
@@ -142,19 +141,49 @@ async def list_downloaded_files(
     }
 
 
-async def get_download_metadata(file_path: str) -> Dict[str, Any]:
+async def get_download_metadata(
+    file_path: str,
+    profile_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Get metadata for a downloaded file.
 
     Retrieves metadata associated with a downloaded file, including
     any custom metadata stored alongside the file. Falls back to
     basic file information if no metadata is available.
 
-    :param file_path: Path to the downloaded file
+    The ``profile_id`` argument is required for multi-tenant isolation:
+    ``file_path`` is interpreted as relative to
+    ``data/profiles/{profile_id}/`` and is rejected if it contains
+    absolute segments, ``..`` components, or resolves outside that
+    directory.
+
+    :param file_path: Profile-relative path to the downloaded file.
     :type file_path: str
-    :return: Dictionary containing file metadata and status
+    :param profile_id: Profile ID that owns the file. Required.
+    :type profile_id: Optional[str]
+    :return: Dictionary containing file metadata and status.
     :rtype: Dict[str, Any]
     """
-    path = Path(file_path)
+    if not profile_id:
+        return {
+            "success": False,
+            "error": "profile_id is required",
+            "file_path": file_path,
+        }
+
+    from ..utils.paths import PathTraversalError, safe_join_within
+
+    handler = get_download_handler()
+    profile_dir = handler.base_dir / "profiles" / profile_id
+
+    try:
+        path = safe_join_within(profile_dir, file_path)
+    except PathTraversalError:
+        return {
+            "success": False,
+            "error": "Invalid file path",
+            "file_path": file_path,
+        }
 
     if not path.exists():
         return {

--- a/src/amazon_ads_mcp/tools/oauth.py
+++ b/src/amazon_ads_mcp/tools/oauth.py
@@ -52,11 +52,27 @@ class OAuthTools:
         self.client_id = settings.ad_api_client_id
         self.client_secret = settings.ad_api_client_secret
         self.region = settings.amazon_ads_region
-        # Use PORT env var (set at runtime) or settings.mcp_server_port or default to 9080
+
+        # Redirect URI resolution order:
+        #   1. Explicit OAUTH_REDIRECT_URI setting (required for any
+        #      deployment behind a proxy, load balancer, or on a non-local
+        #      host). Amazon rejects OAuth flows whose redirect_uri does
+        #      not match the registered application URL exactly, so this
+        #      must be operator-controllable.
+        #   2. Fall back to http://localhost:<port>/auth/callback for
+        #      local developer ergonomics only.
         import os
 
-        port = os.getenv("PORT") or getattr(settings, "mcp_server_port", None) or 9080
-        self.redirect_uri = f"http://localhost:{port}/auth/callback"
+        configured = getattr(settings, "oauth_redirect_uri", None)
+        if configured:
+            self.redirect_uri = configured
+        else:
+            port = (
+                os.getenv("PORT")
+                or getattr(settings, "mcp_server_port", None)
+                or 9080
+            )
+            self.redirect_uri = f"http://localhost:{port}/auth/callback"
 
     async def start_oauth_flow(
         self,

--- a/src/amazon_ads_mcp/utils/errors.py
+++ b/src/amazon_ads_mcp/utils/errors.py
@@ -400,6 +400,29 @@ class ExternalServiceError(MCPError):
         self.service = service
 
 
+class DownloadTooLargeError(MCPError):
+    """Raised when a streamed download exceeds the configured size cap.
+
+    :param size: Observed size in bytes (partial count when streamed).
+    :type size: int
+    :param max_size: Configured maximum size in bytes.
+    :type max_size: int
+    """
+
+    def __init__(self, size: int, max_size: int, **kwargs):
+        details = kwargs.pop("details", {})
+        details.update({"size": size, "max_size": max_size})
+        super().__init__(
+            f"Download exceeds max size: {size} > {max_size} bytes",
+            category=ErrorCategory.VALIDATION,
+            status_code=413,
+            details=details,
+            **kwargs,
+        )
+        self.size = size
+        self.max_size = max_size
+
+
 # =============================================================================
 # Error Pattern Models
 # =============================================================================

--- a/src/amazon_ads_mcp/utils/export_download_handler.py
+++ b/src/amazon_ads_mcp/utils/export_download_handler.py
@@ -32,7 +32,9 @@ Environment Variables:
     - AMAZON_ADS_DOWNLOAD_DIR: Custom download directory path
 """
 
+import asyncio
 import gzip
+import hashlib
 import json
 import logging
 import re
@@ -366,58 +368,104 @@ class ExportDownloadHandler:
 
         validate_download_url(export_url)
 
-        # Use plain httpx client for S3 URLs (they don't need auth headers)
+        from ..config.settings import settings as _settings
+        from .errors import DownloadTooLargeError
+
+        max_size = int(getattr(_settings, "download_max_file_size", 512 * 1024 * 1024))
+        chunk_size = 1024 * 1024  # 1 MiB
+
+        # Stream the body to disk so we never hold the full payload in memory
+        # and can abort as soon as the configured cap is reached.
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(60.0),
             follow_redirects=False,
         ) as client:
-            response = await client.get(export_url)
-        response.raise_for_status()
+            async with client.stream("GET", export_url) as response:
+                response.raise_for_status()
 
-        # Determine filename and gzip state
-        cd = response.headers.get("content-disposition")
-        ct = response.headers.get("content-type")
-        filename, is_gzipped = self._infer_filename_and_type(
-            export_url, cd, ct, export_id
-        )
+                # Pre-check advertised size when available
+                content_length_header = response.headers.get("content-length")
+                if content_length_header:
+                    try:
+                        advertised = int(content_length_header)
+                    except ValueError:
+                        advertised = -1
+                    if advertised > max_size:
+                        raise DownloadTooLargeError(advertised, max_size)
 
-        # Paths
-        file_path = resource_path / filename
-        final_path = file_path
+                cd = response.headers.get("content-disposition")
+                ct = response.headers.get("content-type")
+                filename, is_gzipped = self._infer_filename_and_type(
+                    export_url, cd, ct, export_id
+                )
 
-        # Save original bytes
-        content_bytes = response.content
-        with open(file_path, "wb") as f:
-            f.write(content_bytes)
+                file_path = resource_path / filename
+                final_path = file_path
+                total_bytes = 0
+                try:
+                    with open(file_path, "wb") as f:
+                        async for chunk in response.aiter_bytes(chunk_size):
+                            if not chunk:
+                                continue
+                            total_bytes += len(chunk)
+                            if total_bytes > max_size:
+                                raise DownloadTooLargeError(total_bytes, max_size)
+                            await asyncio.to_thread(f.write, chunk)
+                except BaseException:
+                    # Clean up partial file on any failure (cap breach, I/O, cancel)
+                    try:
+                        file_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    raise
 
-        # If gzipped, also decompress to base (without .gz)
+        # Optionally decompress gzipped streams to a sibling file without
+        # holding the full payload in memory.
         if is_gzipped and filename.endswith(".gz"):
+            base_name = filename[:-3]
+            decompressed_path = resource_path / base_name
+
+            def _decompress() -> None:
+                with gzip.open(file_path, "rb") as src, open(
+                    decompressed_path, "wb"
+                ) as dst:
+                    while True:
+                        block = src.read(chunk_size)
+                        if not block:
+                            break
+                        dst.write(block)
+
             try:
-                decompressed = gzip.decompress(content_bytes)
-                base_name = filename[:-3]  # strip .gz
-                decompressed_path = resource_path / base_name
-                with open(decompressed_path, "wb") as out:
-                    out.write(decompressed)
+                await asyncio.to_thread(_decompress)
                 final_path = decompressed_path
                 logger.info(
-                    f"Downloaded and decompressed export to: {final_path} (original: {file_path})"
+                    "Downloaded and decompressed export to: %s (original: %s)",
+                    final_path,
+                    file_path,
                 )
             except Exception as e:
+                try:
+                    decompressed_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
                 logger.warning(
-                    f"Failed to decompress gzip content, keeping original: {e}"
+                    "Failed to decompress gzip content, keeping original: %s", e
                 )
         else:
-            logger.info(f"Downloaded export to: {final_path}")
+            logger.info("Downloaded export to: %s", final_path)
 
-        # Save metadata if provided
         if metadata:
             meta_path = final_path.with_suffix(".meta.json")
-            metadata = dict(metadata)  # shallow copy to avoid side effects
+            metadata = dict(metadata)
             metadata["download_timestamp"] = datetime.now().isoformat()
             metadata["export_id"] = export_id
             metadata["export_type"] = export_type
-            metadata["original_url"] = export_url
-            metadata["file_size"] = len(content_bytes)
+            # Do not persist the raw pre-signed URL; store a hash only so any
+            # tokens embedded in the URL do not rest on disk.
+            metadata["original_url_sha256"] = hashlib.sha256(
+                export_url.encode("utf-8")
+            ).hexdigest()
+            metadata["file_size"] = total_bytes
             metadata["original_filename"] = filename
             metadata["content_type"] = ct
             metadata["gzipped"] = is_gzipped
@@ -425,11 +473,20 @@ class ExportDownloadHandler:
             if profile_id:
                 metadata["profile_id"] = profile_id
 
-            with open(meta_path, "w", encoding="utf-8") as f:
-                json.dump(metadata, f, indent=2)
-            logger.debug(f"Saved metadata to: {meta_path}")
+            await asyncio.to_thread(
+                self._write_json_atomic, meta_path, metadata
+            )
+            logger.debug("Saved metadata to: %s", meta_path)
 
         return final_path
+
+    @staticmethod
+    def _write_json_atomic(path: Path, data: dict) -> None:
+        """Write JSON metadata via a temp-file swap to avoid torn writes."""
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        tmp.replace(path)
 
     async def handle_export_response(
         self,

--- a/src/amazon_ads_mcp/utils/http/resilience.py
+++ b/src/amazon_ads_mcp/utils/http/resilience.py
@@ -446,13 +446,18 @@ class ResilientRetry:
                         # Network errors and timeouts are retryable
                         should_retry = True
 
-                    # Record failure
-                    if self.use_circuit_breaker and url:
-                        breaker = get_circuit_breaker(endpoint)
-                        breaker.record_failure()
+                    # Do NOT record a circuit-breaker failure per attempt:
+                    # with max_attempts=3 every transient error would
+                    # count as 3 failures and trip the breaker after a
+                    # single logical request. Count at most one failure
+                    # per logical request, recorded only when we exit
+                    # the loop without success.
 
                     if not should_retry or attempt >= self.max_attempts:
                         logger.error(f"Request failed after {attempt} attempts: {e}")
+                        if self.use_circuit_breaker and url:
+                            breaker = get_circuit_breaker(endpoint)
+                            breaker.record_failure()
                         raise
 
                     # Calculate delay
@@ -475,6 +480,9 @@ class ResilientRetry:
 
                     if delay <= 0:
                         logger.error("No time left in retry budget")
+                        if self.use_circuit_breaker and url:
+                            breaker = get_circuit_breaker(endpoint)
+                            breaker.record_failure()
                         raise
 
                     metrics.record_retry(endpoint, attempt, delay)

--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -157,21 +157,14 @@ class AuthenticatedClient(httpx.AsyncClient):
         :rtype: httpx.Response
         :raises httpx.RequestError: When required auth headers are missing
         """
-        # Check if already processed (idempotent) - CRITICAL for preventing double injection
-        if request.extensions.get("auth_injected"):
-            logger.debug(
-                f"Request already processed, skipping injection: {request.method} {request.url}"
-            )
-            return await super().send(request, **kwargs)
-
-        # Mark as processing to prevent concurrent/recursive injection
-        request.extensions["auth_injected"] = True
-
-        # Log incoming request for debugging (only once)
+        # Always (re-)inject auth headers on send. This matters for the
+        # retry path: when a 401 triggers a token refresh between
+        # attempts, the retry must pick up the fresh Authorization
+        # header. Injection is idempotent: the helper overwrites the
+        # Amazon auth headers, so re-calling it is safe.
         logger.debug(f"=== SEND: {request.method} {request.url}")
         logger.debug(f"    Headers before injection: {list(request.headers.keys())}")
 
-        # Inject headers (only once)
         await self._inject_headers(request)
 
         logger.debug(f"Headers injected for {request.method} {request.url}")

--- a/src/amazon_ads_mcp/utils/paths.py
+++ b/src/amazon_ads_mcp/utils/paths.py
@@ -1,0 +1,58 @@
+"""Path-containment helpers for user-supplied file paths.
+
+Provides :func:`safe_join_within`, a single source of truth for resolving
+a user-supplied relative path against a base directory and ensuring the
+result stays inside that base directory (symlink-aware).
+
+The MCP file download tools and the corresponding HTTP routes must share
+this logic so that both control-plane and data-plane paths reject the
+same traversal attempts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+
+class PathTraversalError(ValueError):
+    """Raised when a user-supplied path escapes its base directory."""
+
+
+def safe_join_within(base: Path, user_path: str) -> Path:
+    """Join *user_path* to *base* and verify the result stays inside *base*.
+
+    The check is symlink-aware: both the joined path and the base directory
+    are fully resolved before the containment test. Absolute paths and
+    paths containing explicit ``..`` components are rejected up front so
+    the caller never touches the filesystem on an obviously malicious
+    input.
+
+    :param base: Trusted base directory.
+    :type base: Path
+    :param user_path: Caller-supplied relative path (e.g. from a tool
+        argument or URL segment).
+    :type user_path: str
+    :return: Fully resolved path that is guaranteed to be inside
+        ``base.resolve()``.
+    :rtype: Path
+    :raises PathTraversalError: If ``user_path`` is absolute, contains
+        ``..`` components, or resolves outside *base*.
+    """
+    if not user_path:
+        raise PathTraversalError("empty path")
+
+    candidate = PurePosixPath(user_path.replace("\\", "/"))
+    if candidate.is_absolute():
+        raise PathTraversalError(f"absolute paths are not allowed: {user_path!r}")
+    if any(part == ".." for part in candidate.parts):
+        raise PathTraversalError(f"parent references are not allowed: {user_path!r}")
+
+    base_resolved = base.resolve()
+    joined = (base / user_path).resolve()
+    try:
+        joined.relative_to(base_resolved)
+    except ValueError as exc:
+        raise PathTraversalError(
+            f"path {user_path!r} escapes base directory {base_resolved}"
+        ) from exc
+    return joined

--- a/tests/unit/test_auth_refresh_singleflight.py
+++ b/tests/unit/test_auth_refresh_singleflight.py
@@ -1,0 +1,96 @@
+"""Verify that concurrent ``get_active_credentials`` for the same
+identity coalesce into a single provider fetch."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from amazon_ads_mcp.auth.base import BaseAmazonAdsProvider, BaseIdentityProvider
+from amazon_ads_mcp.auth.manager import AuthManager
+from amazon_ads_mcp.auth.token_store import InMemoryTokenStore
+from amazon_ads_mcp.models import AuthCredentials, Identity, Token
+
+
+class SlowIdentityProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
+    """Provider whose ``get_identity_credentials`` sleeps, so N concurrent
+    callers racing past the cache check overlap in time."""
+
+    def __init__(self, identity_id: str, delay: float = 0.05) -> None:
+        self._identity = Identity(
+            id=identity_id, type="multi", attributes={"region": "na"}
+        )
+        self._delay = delay
+        self.calls = 0
+
+    @property
+    def provider_type(self) -> str:
+        return "multi"
+
+    @property
+    def region(self) -> str:
+        return "na"
+
+    async def initialize(self) -> None: ...
+
+    async def get_token(self) -> Token:
+        return Token(
+            value="static",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    async def validate_token(self, token: Token) -> bool:
+        return True
+
+    async def get_headers(self) -> dict:
+        return {"Amazon-Advertising-API-ClientId": "client-id"}
+
+    async def close(self) -> None: ...
+
+    async def list_identities(self, **kwargs):
+        return [self._identity]
+
+    async def get_identity(self, identity_id: str):
+        return self._identity if identity_id == self._identity.id else None
+
+    async def get_identity_credentials(self, identity_id: str) -> AuthCredentials:
+        self.calls += 1
+        await asyncio.sleep(self._delay)
+        return AuthCredentials(
+            identity_id=identity_id,
+            access_token=f"fresh-{self.calls}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            base_url="https://example.com",
+            headers={"Amazon-Advertising-API-ClientId": "client-id"},
+        )
+
+
+@pytest.fixture
+def auth_manager(monkeypatch):
+    AuthManager.reset()
+    monkeypatch.setattr(AuthManager, "_setup_provider", lambda self: None)
+    manager = AuthManager()
+    manager.provider = None
+    manager._token_store = InMemoryTokenStore()
+    manager._default_profile_id = None
+    yield manager
+    AuthManager.reset()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refreshes_coalesce(auth_manager):
+    provider = SlowIdentityProvider("id-1", delay=0.05)
+    auth_manager.provider = provider
+    await auth_manager.set_active_identity("id-1")
+
+    results = await asyncio.gather(
+        *[auth_manager.get_active_credentials() for _ in range(50)]
+    )
+
+    # Only one provider fetch should have happened.
+    assert provider.calls == 1
+    # All callers received the same credential object reference.
+    assert all(r.access_token == "fresh-1" for r in results)
+    assert all(r.identity_id == "id-1" for r in results)

--- a/tests/unit/test_authenticated_client.py
+++ b/tests/unit/test_authenticated_client.py
@@ -116,25 +116,22 @@ class TestAuthenticatedClient:
             assert sent_request.headers.get("authorization") == "Bearer test-token"
             assert sent_request.headers.get("Amazon-Advertising-API-ClientId") is not None
     
-    async def test_idempotent_injection(self, authenticated_client):
-        """Test that headers are only injected once."""
+    async def test_headers_reinjected_on_every_send(self, authenticated_client):
+        """Headers must be (re-)injected on every ``send`` so retry attempts
+        pick up refreshed tokens. The legacy ``auth_injected`` short-circuit
+        broke refresh-during-retry and has been removed."""
         request = httpx.Request(
             method="GET",
             url="https://advertising-api.amazon.com/test"
         )
-        
-        # Mark as already processed
-        request.extensions["auth_injected"] = True
-        
+
         with patch.object(authenticated_client, '_inject_headers', new_callable=AsyncMock) as mock_inject:
             with patch.object(httpx.AsyncClient, 'send', new_callable=AsyncMock) as mock_send:
-                mock_response = httpx.Response(200)
-                mock_send.return_value = mock_response
-                
+                mock_send.return_value = httpx.Response(200)
                 await authenticated_client.send(request)
-                
-                # Verify injection was skipped
-                mock_inject.assert_not_called()
+                await authenticated_client.send(request)
+
+                assert mock_inject.await_count == 2
     
     async def test_media_type_negotiation(self, authenticated_client, mock_media_registry):
         """Test that media types are negotiated from registry."""

--- a/tests/unit/test_authentication_middleware.py
+++ b/tests/unit/test_authentication_middleware.py
@@ -417,3 +417,35 @@ async def test_auth_session_state_persists_across_tool_calls():
         return current.id if current else None
 
     assert await middleware.on_request(ctx2, second_call_next) == "3175"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_middleware_fails_closed_on_unexpected_error():
+    """Unexpected errors during auth pre-processing must reject the request,
+    not silently continue with a missing/stale identity."""
+    from fastmcp.exceptions import ToolError
+
+    config = AuthConfig()
+    config.enabled = False
+    config.refresh_token_enabled = False
+
+    middleware = RefreshTokenMiddleware(config, auth_manager=None)
+
+    class ExplodingRequest:
+        @property
+        def headers(self):
+            raise RuntimeError("boom: headers unavailable")
+
+    class ExplodingFastMCPContext:
+        def __init__(self):
+            self.request_context = DummyRequestContext(ExplodingRequest())
+
+    ctx = DummyContext(ExplodingFastMCPContext())
+
+    async def call_next(_):
+        pytest.fail(
+            "call_next must not run after auth pre-processing raises"
+        )
+
+    with pytest.raises(ToolError):
+        await middleware.on_request(ctx, call_next)

--- a/tests/unit/test_download_paths.py
+++ b/tests/unit/test_download_paths.py
@@ -1,0 +1,140 @@
+"""Path-containment tests for file download tools.
+
+These tests exercise :func:`amazon_ads_mcp.utils.paths.safe_join_within`
+directly and through the two consumers that must apply it:
+
+* :func:`amazon_ads_mcp.tools.download_tools.get_download_metadata`
+* the MCP ``get_download_url`` tool (the body lives in
+  ``server/builtin_tools.py``; we exercise the same containment code
+  path by invoking ``safe_join_within`` the same way the tool does).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from amazon_ads_mcp.tools import download_tools
+from amazon_ads_mcp.utils.paths import PathTraversalError, safe_join_within
+
+
+class _FakeHandler:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+@pytest.fixture()
+def profile_tree(tmp_path: Path) -> tuple[Path, str]:
+    profile_id = "test_profile"
+    (tmp_path / "profiles" / profile_id / "exports" / "campaigns").mkdir(parents=True)
+    return tmp_path, profile_id
+
+
+# ---------------------------------------------------------------------------
+# safe_join_within
+# ---------------------------------------------------------------------------
+
+
+def test_safe_join_within_accepts_relative_nested(profile_tree):
+    base, profile_id = profile_tree
+    profile_dir = base / "profiles" / profile_id
+    file_path = profile_dir / "exports" / "campaigns" / "ok.json"
+    file_path.write_text("x")
+
+    result = safe_join_within(profile_dir, "exports/campaigns/ok.json")
+    assert result == file_path.resolve()
+
+
+def test_safe_join_within_rejects_absolute(profile_tree):
+    base, profile_id = profile_tree
+    profile_dir = base / "profiles" / profile_id
+    with pytest.raises(PathTraversalError):
+        safe_join_within(profile_dir, "/etc/passwd")
+
+
+def test_safe_join_within_rejects_dot_dot(profile_tree):
+    base, profile_id = profile_tree
+    profile_dir = base / "profiles" / profile_id
+    for bad in ("../escape.csv", "a/../../escape.csv", "..\\escape"):
+        with pytest.raises(PathTraversalError):
+            safe_join_within(profile_dir, bad)
+
+
+def test_safe_join_within_rejects_empty(profile_tree):
+    base, profile_id = profile_tree
+    profile_dir = base / "profiles" / profile_id
+    with pytest.raises(PathTraversalError):
+        safe_join_within(profile_dir, "")
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="symlinks require admin on Windows"
+)
+def test_safe_join_within_rejects_symlink_escape(tmp_path: Path):
+    profile_dir = tmp_path / "profiles" / "p1"
+    profile_dir.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("top-secret")
+
+    # Symlink inside the profile dir pointing outside it.
+    link = profile_dir / "link"
+    os.symlink(outside, link)
+
+    with pytest.raises(PathTraversalError):
+        safe_join_within(profile_dir, "link/secret.txt")
+
+
+# ---------------------------------------------------------------------------
+# get_download_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_download_metadata_rejects_absolute(monkeypatch, profile_tree):
+    base, profile_id = profile_tree
+    monkeypatch.setattr(
+        download_tools, "get_download_handler", lambda: _FakeHandler(base)
+    )
+
+    result = await download_tools.get_download_metadata(
+        "/etc/passwd", profile_id=profile_id
+    )
+    assert result["success"] is False
+    assert result["error"] == "Invalid file path"
+
+
+@pytest.mark.asyncio
+async def test_get_download_metadata_rejects_traversal(monkeypatch, profile_tree):
+    base, profile_id = profile_tree
+    monkeypatch.setattr(
+        download_tools, "get_download_handler", lambda: _FakeHandler(base)
+    )
+
+    result = await download_tools.get_download_metadata(
+        "../../outside.csv", profile_id=profile_id
+    )
+    assert result["success"] is False
+    assert result["error"] == "Invalid file path"
+
+
+@pytest.mark.asyncio
+async def test_get_download_metadata_accepts_nested(monkeypatch, profile_tree):
+    base, profile_id = profile_tree
+    target = base / "profiles" / profile_id / "exports" / "campaigns" / "e.csv"
+    target.write_text("data")
+    target.with_suffix(".meta.json").write_text('{"k": "v"}')
+
+    monkeypatch.setattr(
+        download_tools, "get_download_handler", lambda: _FakeHandler(base)
+    )
+
+    result = await download_tools.get_download_metadata(
+        "exports/campaigns/e.csv", profile_id=profile_id
+    )
+    assert result["success"] is True
+    assert result["metadata"]["k"] == "v"

--- a/tests/unit/test_download_tools.py
+++ b/tests/unit/test_download_tools.py
@@ -96,26 +96,62 @@ async def test_list_downloaded_files_summarizes(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_get_download_metadata_reads_meta(tmp_path):
-    file_path = tmp_path / "export.csv"
+async def test_get_download_metadata_reads_meta(monkeypatch, tmp_path):
+    profile_id = "test_profile"
+    profile_dir = tmp_path / "profiles" / profile_id / "exports" / "campaigns"
+    profile_dir.mkdir(parents=True)
+
+    file_path = profile_dir / "export.csv"
     file_path.write_text("data")
     meta_path = file_path.with_suffix(".meta.json")
     meta_path.write_text('{"foo": "bar"}')
 
-    result = await download_tools.get_download_metadata(str(file_path))
+    handler = FakeHandler(tmp_path)
+    monkeypatch.setattr(download_tools, "get_download_handler", lambda: handler)
+
+    result = await download_tools.get_download_metadata(
+        "exports/campaigns/export.csv", profile_id=profile_id
+    )
 
     assert result["success"] is True
     assert result["metadata"]["foo"] == "bar"
 
 
 @pytest.mark.asyncio
-async def test_get_download_metadata_missing_file(tmp_path):
-    missing_path = tmp_path / "missing.csv"
+async def test_get_download_metadata_missing_file(monkeypatch, tmp_path):
+    profile_id = "test_profile"
+    (tmp_path / "profiles" / profile_id).mkdir(parents=True)
+    handler = FakeHandler(tmp_path)
+    monkeypatch.setattr(download_tools, "get_download_handler", lambda: handler)
 
-    result = await download_tools.get_download_metadata(str(missing_path))
+    result = await download_tools.get_download_metadata(
+        "missing.csv", profile_id=profile_id
+    )
 
     assert result["success"] is False
     assert result["error"] == "File not found"
+
+
+@pytest.mark.asyncio
+async def test_get_download_metadata_requires_profile_id(tmp_path):
+    result = await download_tools.get_download_metadata("any.csv")
+    assert result["success"] is False
+    assert "profile_id is required" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_download_metadata_rejects_traversal(monkeypatch, tmp_path):
+    profile_id = "test_profile"
+    (tmp_path / "profiles" / profile_id).mkdir(parents=True)
+    handler = FakeHandler(tmp_path)
+    monkeypatch.setattr(download_tools, "get_download_handler", lambda: handler)
+
+    for bad in ("../escape.csv", "/etc/passwd", "a/../../escape.csv"):
+        result = await download_tools.get_download_metadata(
+            bad, profile_id=profile_id
+        )
+        assert result["success"] is False
+        assert result["error"] == "Invalid file path"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_export_download_handler.py
+++ b/tests/unit/test_export_download_handler.py
@@ -5,45 +5,178 @@ downloading and processing Amazon Ads API exports.
 """
 
 import asyncio
+import gzip
+import hashlib
+import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch, MagicMock
 
+import httpx
+import pytest
+
+from amazon_ads_mcp.utils.errors import DownloadTooLargeError
 from amazon_ads_mcp.utils.export_download_handler import ExportDownloadHandler
 
 
-async def _run_download(tmp_path: Path):
-    h = ExportDownloadHandler(base_dir=tmp_path)
-    
-    # Create mock response
-    mock_response = AsyncMock()
-    mock_response.headers = {
-        "content-disposition": 'attachment; filename="report.csv"',
-        "content-type": "text/csv",
-    }
-    mock_response.content = b"a,b\n1,2\n"
-    mock_response.raise_for_status = MagicMock()
-    
-    # Create mock client with async context manager support
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(return_value=mock_response)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    
-    # Patch the httpx.AsyncClient constructor to return our mock
-    with patch('httpx.AsyncClient') as mock_async_client:
-        mock_async_client.return_value = mock_client
-        
-        out = await h.download_export(
-            export_url="https://offline-report-storage.s3.amazonaws.com/exports/abc",
+def _make_transport(
+    payload: bytes,
+    *,
+    content_type: str = "text/csv",
+    content_disposition: str = 'attachment; filename="report.csv"',
+    content_length: int | None = None,
+):
+    """Build a MockTransport that yields ``payload`` for any GET.
+
+    Uses streaming bytes so the handler exercises ``aiter_bytes``.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        headers = {"content-type": content_type}
+        if content_disposition:
+            headers["content-disposition"] = content_disposition
+        if content_length is not None:
+            headers["content-length"] = str(content_length)
+        return httpx.Response(200, headers=headers, content=payload)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture(autouse=True)
+def _patch_mock_transport(monkeypatch):
+    """Each test that needs transport injection calls ``_install(payload)``.
+
+    Exposes a helper on the fixture via ``request.node``.
+    """
+    yield
+
+
+def _install_transport(monkeypatch, transport: httpx.MockTransport) -> None:
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_ssrf(monkeypatch):
+    """Disable SSRF network resolution in tests."""
+    from amazon_ads_mcp.utils import security
+
+    monkeypatch.setattr(security, "validate_download_url", lambda url: url)
+
+
+def _download_url() -> str:
+    return "https://offline-report-storage.s3.amazonaws.com/exports/abc"
+
+
+def test_download_export_writes_file(tmp_path: Path, monkeypatch):
+    handler = ExportDownloadHandler(base_dir=tmp_path)
+    payload = b"a,b\n1,2\n"
+    _install_transport(monkeypatch, _make_transport(payload))
+
+    out = asyncio.run(
+        handler.download_export(
+            export_url=_download_url(),
             export_id="abc",
             export_type="campaigns",
             metadata={"k": "v"},
         )
-    return out
+    )
 
-
-def test_download_export_writes_file(tmp_path: Path):
-    out = asyncio.run(_run_download(tmp_path))
     assert out.exists()
+    assert out.read_bytes() == payload
     meta = out.with_suffix(".meta.json")
     assert meta.exists()
+    meta_obj = json.loads(meta.read_text())
+    assert meta_obj["file_size"] == len(payload)
+    # URL must NOT be persisted raw; hash only.
+    assert "original_url" not in meta_obj
+    assert meta_obj["original_url_sha256"] == hashlib.sha256(
+        _download_url().encode()
+    ).hexdigest()
+
+
+def test_download_export_aborts_when_over_cap(tmp_path: Path, monkeypatch):
+    handler = ExportDownloadHandler(base_dir=tmp_path)
+
+    # Cap to 128 bytes; payload is 1 KiB so streaming must trip over it.
+    from amazon_ads_mcp.config import settings as settings_mod
+
+    monkeypatch.setattr(
+        settings_mod.settings, "download_max_file_size", 128, raising=False
+    )
+
+    payload = b"x" * 1024
+    _install_transport(monkeypatch, _make_transport(payload))
+
+    with pytest.raises(DownloadTooLargeError):
+        asyncio.run(
+            handler.download_export(
+                export_url=_download_url(),
+                export_id="abc",
+                export_type="campaigns",
+            )
+        )
+
+    # No partial file should remain.
+    leftovers = list(
+        (tmp_path).rglob("*.csv")
+    ) + list((tmp_path).rglob("*.bin"))
+    assert leftovers == []
+
+
+def test_download_export_rejects_on_content_length(tmp_path: Path, monkeypatch):
+    handler = ExportDownloadHandler(base_dir=tmp_path)
+
+    from amazon_ads_mcp.config import settings as settings_mod
+
+    monkeypatch.setattr(
+        settings_mod.settings, "download_max_file_size", 128, raising=False
+    )
+
+    payload = b"x" * 64  # under cap, but advertise over cap
+    _install_transport(
+        monkeypatch,
+        _make_transport(payload, content_length=10_000),
+    )
+
+    with pytest.raises(DownloadTooLargeError):
+        asyncio.run(
+            handler.download_export(
+                export_url=_download_url(),
+                export_id="abc",
+                export_type="campaigns",
+            )
+        )
+
+
+def test_download_export_streams_gzip(tmp_path: Path, monkeypatch):
+    handler = ExportDownloadHandler(base_dir=tmp_path)
+    raw = b"col1,col2\n1,2\n3,4\n"
+    gz = gzip.compress(raw)
+    _install_transport(
+        monkeypatch,
+        _make_transport(
+            gz,
+            content_type="application/gzip",
+            content_disposition='attachment; filename="report.csv.gz"',
+        ),
+    )
+
+    out = asyncio.run(
+        handler.download_export(
+            export_url=_download_url(),
+            export_id="abc",
+            export_type="campaigns",
+        )
+    )
+
+    # The decompressed sibling becomes the final path
+    assert out.suffix == ".csv"
+    assert out.exists()
+    assert out.read_bytes() == raw
+    # Original .gz is preserved next to it
+    gz_path = out.with_suffix(".csv.gz")
+    assert gz_path.exists()

--- a/tests/unit/test_export_download_handler_profile_scoping.py
+++ b/tests/unit/test_export_download_handler_profile_scoping.py
@@ -7,9 +7,46 @@ Run with: uv run pytest tests/unit/test_export_download_handler_profile_scoping.
 import json
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared transport helpers (streaming-compatible)
+# ---------------------------------------------------------------------------
+
+
+def _make_transport(
+    payload: bytes = b'{"test": "data"}',
+    *,
+    content_type: str = "application/json",
+    content_disposition: str = 'attachment; filename="test.json"',
+) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        headers = {"content-type": content_type}
+        if content_disposition:
+            headers["content-disposition"] = content_disposition
+        return httpx.Response(200, headers=headers, content=payload)
+
+    return httpx.MockTransport(handler)
+
+
+def _install_transport(monkeypatch, transport: httpx.MockTransport) -> None:
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_ssrf(monkeypatch):
+    from amazon_ads_mcp.utils import security
+
+    monkeypatch.setattr(security, "validate_download_url", lambda url: url)
 
 
 # =============================================================================
@@ -22,12 +59,10 @@ class TestProfileScopedResourcePath:
 
     @pytest.fixture
     def temp_base_dir(self):
-        """Create a temporary base directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
     def test_get_resource_path_with_profile_id(self, temp_base_dir):
-        """Should return profile-scoped path when profile_id provided."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -40,13 +75,11 @@ class TestProfileScopedResourcePath:
             profile_id="profile_123",
         )
 
-        # Should be under profiles/{profile_id}/
         assert "profiles" in path.parts
         assert "profile_123" in path.parts
         assert path.exists()
 
     def test_get_resource_path_without_profile_id_is_legacy(self, temp_base_dir):
-        """Should return legacy path when profile_id is None (backward compat)."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -59,13 +92,10 @@ class TestProfileScopedResourcePath:
             profile_id=None,
         )
 
-        # Should NOT be under profiles/
         assert "profiles" not in path.parts
-        # Should still have resource type
         assert "exports" in path.parts or "downloads" in path.parts
 
     def test_profile_path_structure(self, temp_base_dir):
-        """Profile path should follow: profiles/{profile_id}/{resource_type}/{sub_type}."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -78,17 +108,14 @@ class TestProfileScopedResourcePath:
             profile_id="12345",
         )
 
-        # Verify structure
         relative = path.relative_to(temp_base_dir)
         parts = relative.parts
 
         assert parts[0] == "profiles"
         assert parts[1] == "12345"
-        # Resource type and sub_type follow
         assert len(parts) >= 3
 
     def test_different_profiles_get_different_directories(self, temp_base_dir):
-        """Different profile IDs should result in different directories."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -117,115 +144,72 @@ class TestProfileScopedResourcePath:
 
 
 class TestProfileScopedDownload:
-    """Tests for profile-scoped file downloads."""
-
     @pytest.fixture
     def temp_base_dir(self):
-        """Create a temporary base directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
-    @pytest.fixture
-    def mock_httpx_response(self):
-        """Create a mock httpx response."""
-        response = Mock()
-        response.content = b'{"test": "data"}'
-        response.headers = {
-            "content-type": "application/json",
-            "content-disposition": 'attachment; filename="test.json"',
-        }
-        response.raise_for_status = Mock()
-        return response
-
     @pytest.mark.asyncio
     async def test_download_export_with_profile_saves_to_profile_dir(
-        self, temp_base_dir, mock_httpx_response
+        self, temp_base_dir, monkeypatch
     ):
-        """Downloads with profile_id should save to profile-scoped directory."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
 
         handler = ExportDownloadHandler(base_dir=temp_base_dir)
+        _install_transport(monkeypatch, _make_transport())
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.get = AsyncMock(return_value=mock_httpx_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(
-                return_value=mock_client
-            )
-            mock_client_class.return_value.__aexit__ = AsyncMock()
+        file_path = await handler.download_export(
+            export_url="https://advertising-api.amazon.com/export.json",
+            export_id="exp_123",
+            export_type="campaigns",
+            profile_id="profile_456",
+        )
 
-            file_path = await handler.download_export(
-                export_url="https://advertising-api.amazon.com/export.json",
-                export_id="exp_123",
-                export_type="campaigns",
-                profile_id="profile_456",
-            )
-
-        # Verify file is under profile directory
         assert "profiles" in file_path.parts
         assert "profile_456" in file_path.parts
         assert file_path.exists()
 
     @pytest.mark.asyncio
     async def test_download_export_without_profile_uses_legacy_path(
-        self, temp_base_dir, mock_httpx_response
+        self, temp_base_dir, monkeypatch
     ):
-        """Downloads without profile_id should use legacy path (backward compat)."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
 
         handler = ExportDownloadHandler(base_dir=temp_base_dir)
+        _install_transport(monkeypatch, _make_transport())
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.get = AsyncMock(return_value=mock_httpx_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(
-                return_value=mock_client
-            )
-            mock_client_class.return_value.__aexit__ = AsyncMock()
+        file_path = await handler.download_export(
+            export_url="https://advertising-api.amazon.com/export.json",
+            export_id="exp_123",
+            export_type="campaigns",
+        )
 
-            file_path = await handler.download_export(
-                export_url="https://advertising-api.amazon.com/export.json",
-                export_id="exp_123",
-                export_type="campaigns",
-                # No profile_id
-            )
-
-        # Verify file is NOT under profile directory
         assert "profiles" not in file_path.parts
         assert file_path.exists()
 
     @pytest.mark.asyncio
     async def test_metadata_includes_profile_id(
-        self, temp_base_dir, mock_httpx_response
+        self, temp_base_dir, monkeypatch
     ):
-        """Metadata should include profile_id when provided."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
 
         handler = ExportDownloadHandler(base_dir=temp_base_dir)
+        _install_transport(monkeypatch, _make_transport())
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.get = AsyncMock(return_value=mock_httpx_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(
-                return_value=mock_client
-            )
-            mock_client_class.return_value.__aexit__ = AsyncMock()
+        file_path = await handler.download_export(
+            export_url="https://advertising-api.amazon.com/export.json",
+            export_id="exp_123",
+            export_type="campaigns",
+            profile_id="profile_789",
+            metadata={"custom": "data"},
+        )
 
-            file_path = await handler.download_export(
-                export_url="https://advertising-api.amazon.com/export.json",
-                export_id="exp_123",
-                export_type="campaigns",
-                profile_id="profile_789",
-                metadata={"custom": "data"},
-            )
-
-        # Check metadata file (with_suffix replaces extension)
         meta_path = file_path.with_suffix(".meta.json")
         assert meta_path.exists()
 
@@ -241,35 +225,21 @@ class TestProfileScopedDownload:
 
 
 class TestHandleExportResponseWithProfile:
-    """Tests for handle_export_response with profile scoping."""
-
     @pytest.fixture
     def temp_base_dir(self):
-        """Create a temporary base directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
-    @pytest.fixture
-    def mock_httpx_response(self):
-        """Create a mock httpx response."""
-        response = Mock()
-        response.content = b'{"test": "data"}'
-        response.headers = {
-            "content-type": "application/json",
-        }
-        response.raise_for_status = Mock()
-        return response
-
     @pytest.mark.asyncio
     async def test_handle_export_response_with_profile_id(
-        self, temp_base_dir, mock_httpx_response
+        self, temp_base_dir, monkeypatch
     ):
-        """handle_export_response should pass profile_id to download_export."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
 
         handler = ExportDownloadHandler(base_dir=temp_base_dir)
+        _install_transport(monkeypatch, _make_transport())
 
         export_response = {
             "status": "COMPLETED",
@@ -277,19 +247,11 @@ class TestHandleExportResponseWithProfile:
             "url": "https://advertising-api.amazon.com/download.json",
         }
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.get = AsyncMock(return_value=mock_httpx_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(
-                return_value=mock_client
-            )
-            mock_client_class.return_value.__aexit__ = AsyncMock()
-
-            file_path = await handler.handle_export_response(
-                export_response=export_response,
-                export_type="campaigns",
-                profile_id="profile_handle_test",
-            )
+        file_path = await handler.handle_export_response(
+            export_response=export_response,
+            export_type="campaigns",
+            profile_id="profile_handle_test",
+        )
 
         assert file_path is not None
         assert "profiles" in file_path.parts
@@ -302,15 +264,11 @@ class TestHandleExportResponseWithProfile:
 
 
 class TestListDownloadsWithProfile:
-    """Tests for listing downloads with profile scoping."""
-
     @pytest.fixture
     def temp_base_dir(self):
-        """Create a temporary base directory with test files."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
 
-            # Create profile-scoped files
             profile_dir = base / "profiles" / "profile_123" / "exports" / "campaigns"
             profile_dir.mkdir(parents=True)
             (profile_dir / "report1.json").write_text('{"test": 1}')
@@ -318,12 +276,10 @@ class TestListDownloadsWithProfile:
                 '{"export_id": "exp1"}'
             )
 
-            # Create another profile's files
             profile2_dir = base / "profiles" / "profile_456" / "exports" / "campaigns"
             profile2_dir.mkdir(parents=True)
             (profile2_dir / "report2.json").write_text('{"test": 2}')
 
-            # Create legacy (non-profile) files
             legacy_dir = base / "exports" / "campaigns"
             legacy_dir.mkdir(parents=True)
             (legacy_dir / "legacy_report.json").write_text('{"legacy": true}')
@@ -331,7 +287,6 @@ class TestListDownloadsWithProfile:
             yield base
 
     def test_list_downloads_for_specific_profile(self, temp_base_dir):
-        """Should only list files for the specified profile."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -340,14 +295,12 @@ class TestListDownloadsWithProfile:
 
         files = handler.list_downloads(profile_id="profile_123")
 
-        # Should only see profile_123's files
         file_names = [f["name"] for f in files]
         assert "report1.json" in file_names
-        assert "report2.json" not in file_names  # Different profile
-        assert "legacy_report.json" not in file_names  # Legacy
+        assert "report2.json" not in file_names
+        assert "legacy_report.json" not in file_names
 
     def test_list_downloads_without_profile_shows_legacy(self, temp_base_dir):
-        """Without profile_id, should show legacy (non-profile) files."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -356,15 +309,12 @@ class TestListDownloadsWithProfile:
 
         files = handler.list_downloads(profile_id=None)
 
-        # Should see legacy files
         file_names = [f["name"] for f in files]
         assert "legacy_report.json" in file_names
-        # Should NOT see profile-scoped files
         assert "report1.json" not in file_names
         assert "report2.json" not in file_names
 
     def test_list_downloads_empty_profile_returns_empty(self, temp_base_dir):
-        """Should return empty list for profile with no downloads."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -382,16 +332,12 @@ class TestListDownloadsWithProfile:
 
 
 class TestGetProfileBaseDir:
-    """Tests for getting the profile-specific base directory."""
-
     @pytest.fixture
     def temp_base_dir(self):
-        """Create a temporary base directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
     def test_get_profile_base_dir_creates_directory(self, temp_base_dir):
-        """Should create and return profile base directory."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -405,14 +351,12 @@ class TestGetProfileBaseDir:
         assert profile_dir.exists()
 
     def test_get_profile_base_dir_returns_existing(self, temp_base_dir):
-        """Should return existing profile directory without error."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
 
         handler = ExportDownloadHandler(base_dir=temp_base_dir)
 
-        # Create it first
         expected = temp_base_dir / "profiles" / "existing_profile"
         expected.mkdir(parents=True)
 
@@ -421,7 +365,6 @@ class TestGetProfileBaseDir:
         assert profile_dir == expected
 
     def test_get_profile_base_dir_none_returns_base(self, temp_base_dir):
-        """Should return base_dir when profile_id is None."""
         from amazon_ads_mcp.utils.export_download_handler import (
             ExportDownloadHandler,
         )
@@ -430,5 +373,4 @@ class TestGetProfileBaseDir:
 
         profile_dir = handler.get_profile_base_dir(None)
 
-        # Should return base_dir for legacy mode
         assert profile_dir == temp_base_dir

--- a/tests/unit/test_file_routes.py
+++ b/tests/unit/test_file_routes.py
@@ -497,9 +497,13 @@ class TestDownloadAuth:
 class TestBaseUrlResolution:
     """Tests for _get_base_url function."""
 
-    def test_uses_forwarded_headers(self):
-        """Should use X-Forwarded-Proto and X-Forwarded-Host when present."""
+    def test_uses_forwarded_headers_only_when_trust_enabled(self, monkeypatch):
+        """Should honor X-Forwarded-* only when the operator has explicitly
+        opted in via AMAZON_ADS_TRUST_FORWARDED_HEADERS=true."""
         from amazon_ads_mcp.server.file_routes import _get_base_url
+
+        monkeypatch.setenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", "true")
+        monkeypatch.delenv("AMAZON_ADS_PUBLIC_BASE_URL", raising=False)
 
         request = Mock()
         request.headers = {
@@ -508,45 +512,58 @@ class TestBaseUrlResolution:
         }
         request.base_url = "http://localhost:9080/"
 
-        result = _get_base_url(request)
+        assert _get_base_url(request) == "https://api.example.com"
 
-        assert result == "https://api.example.com"
-
-    def test_falls_back_to_request_base_url(self):
-        """Should fall back to request.base_url when no forwarded headers."""
+    def test_ignores_forwarded_headers_by_default(self, monkeypatch):
+        """Forwarded headers must be ignored unless explicitly trusted,
+        otherwise any client can forge generated download URLs."""
         from amazon_ads_mcp.server.file_routes import _get_base_url
 
+        monkeypatch.delenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", raising=False)
+        monkeypatch.delenv("AMAZON_ADS_PUBLIC_BASE_URL", raising=False)
+
         request = Mock()
-        request.headers = {}
+        request.headers = {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "attacker.example.com",
+        }
         request.base_url = "http://localhost:9080/"
 
         result = _get_base_url(request)
 
         assert result == "http://localhost:9080"
+        assert "attacker.example.com" not in result
 
-    def test_strips_trailing_slash(self):
-        """Should strip trailing slash from base URL."""
+    def test_public_base_url_wins(self, monkeypatch):
+        """An explicit AMAZON_ADS_PUBLIC_BASE_URL must win over everything."""
         from amazon_ads_mcp.server.file_routes import _get_base_url
+
+        monkeypatch.setenv(
+            "AMAZON_ADS_PUBLIC_BASE_URL", "https://ads.example.com/"
+        )
+        monkeypatch.setenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", "true")
+
+        request = Mock()
+        request.headers = {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "attacker.example.com",
+        }
+        request.base_url = "http://localhost:9080/"
+
+        assert _get_base_url(request) == "https://ads.example.com"
+
+    def test_falls_back_to_request_base_url(self, monkeypatch):
+        """Fall back to request.base_url when no configuration is set."""
+        from amazon_ads_mcp.server.file_routes import _get_base_url
+
+        monkeypatch.delenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", raising=False)
+        monkeypatch.delenv("AMAZON_ADS_PUBLIC_BASE_URL", raising=False)
 
         request = Mock()
         request.headers = {}
         request.base_url = "http://localhost:9080/"
 
-        result = _get_base_url(request)
-
-        assert not result.endswith("/")
-
-    def test_fixes_http_to_https_with_forwarded_proto(self):
-        """Should upgrade HTTP to HTTPS when X-Forwarded-Proto is https."""
-        from amazon_ads_mcp.server.file_routes import _get_base_url
-
-        request = Mock()
-        request.headers = {"X-Forwarded-Proto": "https"}
-        request.base_url = "http://localhost:9080/"
-
-        result = _get_base_url(request)
-
-        assert result.startswith("https://")
+        assert _get_base_url(request) == "http://localhost:9080"
 
 
 # =============================================================================

--- a/tests/unit/test_health_endpoint_version.py
+++ b/tests/unit/test_health_endpoint_version.py
@@ -1,0 +1,24 @@
+"""Regression test: /health must report the real package version."""
+
+from pathlib import Path
+
+from amazon_ads_mcp import __version__
+
+
+def test_health_check_reports_package_version():
+    """The /health response should mirror the installed package version
+    rather than a hardcoded placeholder. Orchestrators and operators
+    depend on this for rollout/rollback tracking."""
+    server_builder_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "amazon_ads_mcp"
+        / "server"
+        / "server_builder.py"
+    )
+    source = server_builder_path.read_text()
+
+    assert '"version": "1.0.0"' not in source
+    assert "package_version" in source
+    assert isinstance(__version__, str)
+    assert __version__

--- a/tests/unit/test_http_client_retry_auth.py
+++ b/tests/unit/test_http_client_retry_auth.py
@@ -1,0 +1,59 @@
+"""Retry scenarios must re-inject authentication headers.
+
+Before this fix, ``AuthenticatedClient.send`` short-circuited on the
+``auth_injected`` request extension, so a retry carried the *original*
+Authorization header even when a background refresh had rotated the
+access token. That defeated 401-triggered refresh-and-retry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+
+@pytest.mark.asyncio
+async def test_send_reinjects_on_each_call():
+    auth_manager = MagicMock()
+    auth_manager.get_headers = AsyncMock(
+        side_effect=[
+            {
+                "Authorization": "Bearer token-v1",
+                "Amazon-Advertising-API-ClientId": "cid",
+            },
+            {
+                "Authorization": "Bearer token-v2",
+                "Amazon-Advertising-API-ClientId": "cid",
+            },
+        ]
+    )
+    auth_manager.provider = MagicMock()
+    # Default provider capability flags to "no" so the client does not
+    # try to rewrite the URL based on identity-region routing.
+    auth_manager.provider.requires_identity_region_routing = lambda: False
+    auth_manager.get_active_identity = lambda: None
+
+    client = AuthenticatedClient(auth_manager=auth_manager)
+
+    captured: list[str] = []
+
+    async def _fake_send(self, request: httpx.Request, **_kwargs) -> httpx.Response:  # noqa: ARG001
+        captured.append(request.headers.get("authorization", ""))
+        return httpx.Response(200)
+
+    with patch.object(httpx.AsyncClient, "send", new=_fake_send):
+        request1 = httpx.Request(
+            "GET", "https://advertising-api.amazon.com/v2/profiles"
+        )
+        await client.send(request1)
+
+        request2 = httpx.Request(
+            "GET", "https://advertising-api.amazon.com/v2/profiles"
+        )
+        await client.send(request2)
+
+    assert captured == ["Bearer token-v1", "Bearer token-v2"]

--- a/tests/unit/test_oauth_state_store.py
+++ b/tests/unit/test_oauth_state_store.py
@@ -1,0 +1,57 @@
+"""Tests for OAuth state signing and validation."""
+
+from amazon_ads_mcp.auth.oauth_state_store import OAuthStateStore
+
+
+def test_state_signature_is_full_sha256():
+    """The HMAC signature component of the state must be the full SHA-256
+    hex digest (64 chars), not a truncated prefix. Truncation weakens
+    forgery resistance."""
+    store = OAuthStateStore(secret_key="test-secret")
+    state = store.generate_state(auth_url="https://example.com/auth")
+
+    state_base, signature = state.rsplit(".", 1)
+    assert len(signature) == 64
+    assert all(c in "0123456789abcdef" for c in signature)
+    # state_base should still be a reasonable length
+    assert len(state_base) >= 16
+
+
+def test_state_validates_roundtrip():
+    store = OAuthStateStore(secret_key="test-secret")
+    state = store.generate_state(auth_url="https://example.com/auth")
+
+    ok, err = store.validate_state(state)
+    assert ok is True
+    assert err is None
+
+
+def test_state_rejects_forged_signature():
+    store = OAuthStateStore(secret_key="test-secret")
+    state = store.generate_state(auth_url="https://example.com/auth")
+    state_base, _ = state.rsplit(".", 1)
+    forged = f"{state_base}.{'0' * 64}"
+
+    # The forged state is not in the in-memory map either, so it should be
+    # rejected on either the existence check or the signature check.
+    ok, err = store.validate_state(forged)
+    assert ok is False
+    assert err is not None
+
+
+def test_state_rejects_tampered_existing_entry():
+    """Even if the attacker knows a valid state token's prefix, swapping
+    the signature suffix to garbage must fail signature validation."""
+    store = OAuthStateStore(secret_key="test-secret")
+    state = store.generate_state(auth_url="https://example.com/auth")
+
+    # Inject a second state with the same base but a wrong signature by
+    # directly manipulating the store to simulate an attacker-chosen token
+    # that made it into storage (e.g. via a replay attempt).
+    state_base, _ = state.rsplit(".", 1)
+    tampered = f"{state_base}.{'f' * 64}"
+    store._memory_store[tampered] = store._memory_store[state]
+
+    ok, err = store.validate_state(tampered)
+    assert ok is False
+    assert err == "Invalid state signature"

--- a/tests/unit/test_oauth_tools.py
+++ b/tests/unit/test_oauth_tools.py
@@ -277,3 +277,22 @@ async def test_handle_oauth_callback_invalid_state(monkeypatch):
 
     assert result["status"] == "error"
     assert result["message"] == "Invalid state"
+
+
+def test_oauth_redirect_uri_uses_configured_setting():
+    """OAUTH_REDIRECT_URI must be honored — Amazon rejects OAuth flows
+    whose redirect_uri does not match the registered value exactly."""
+    settings = DummySettings()
+    settings.oauth_redirect_uri = "https://ads.example.com/auth/callback"
+
+    tools = OAuthTools(settings)
+    assert tools.redirect_uri == "https://ads.example.com/auth/callback"
+
+
+def test_oauth_redirect_uri_defaults_to_localhost():
+    settings = DummySettings()
+    settings.oauth_redirect_uri = None
+
+    tools = OAuthTools(settings)
+    assert tools.redirect_uri.startswith("http://localhost:")
+    assert tools.redirect_uri.endswith("/auth/callback")

--- a/tests/unit/test_resilience_circuit_breaker.py
+++ b/tests/unit/test_resilience_circuit_breaker.py
@@ -1,0 +1,73 @@
+"""Verify circuit-breaker accounting is per-logical-request, not per-attempt.
+
+With ``max_attempts=3`` and a failing upstream, the old code called
+``record_failure()`` inside each retry's except block. A single logical
+request therefore counted as 3 failures against the breaker, and a
+single bad minute could trip the breaker for an entire endpoint family.
+
+After the fix we expect exactly one breaker failure per call even when
+internal retries exhaust.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from amazon_ads_mcp.utils.http import resilience
+from amazon_ads_mcp.utils.http.resilience import (
+    CircuitBreaker,
+    ResilientRetry,
+    get_circuit_breaker,
+)
+
+
+@pytest.mark.asyncio
+async def test_single_failure_per_logical_request(monkeypatch):
+    endpoint = "test-endpoint-singlecall"
+    # Start with a clean breaker.
+    resilience.circuit_breakers[endpoint] = CircuitBreaker(endpoint=endpoint)
+
+    # Pin get_endpoint_family so every request maps to our endpoint.
+    monkeypatch.setattr(
+        resilience, "get_endpoint_family", lambda _url: endpoint
+    )
+    # Short-circuit rate limiter and sleep to keep the test fast.
+    monkeypatch.setattr(
+        resilience, "get_token_bucket", lambda _url: _AlwaysAcquire()
+    )
+
+    async def _instant_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(resilience.asyncio, "sleep", _instant_sleep)
+
+    retry = ResilientRetry(
+        max_attempts=3,
+        initial_delay=0.001,
+        max_delay=0.01,
+        total_timeout=10.0,
+        use_circuit_breaker=True,
+        use_rate_limiter=False,
+    )
+
+    @retry
+    async def failing(request: httpx.Request) -> httpx.Response:
+        response = httpx.Response(503, request=request)
+        raise httpx.HTTPStatusError("boom", request=request, response=response)
+
+    request = httpx.Request("GET", "https://example.invalid/resource")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await failing(request)
+
+    breaker = get_circuit_breaker(endpoint)
+    assert breaker.failure_count == 1, (
+        f"expected exactly one breaker failure per logical request, "
+        f"got {breaker.failure_count}"
+    )
+
+
+class _AlwaysAcquire:
+    async def acquire(self, timeout: float | None = None) -> bool:  # noqa: ARG002
+        return True

--- a/tests/unit/test_token_store.py
+++ b/tests/unit/test_token_store.py
@@ -10,6 +10,7 @@ from amazon_ads_mcp.auth.token_store import (
     TokenEntry,
     TokenKey,
     TokenKind,
+    TokenStoreDecryptError,
     create_token_store,
 )
 
@@ -127,4 +128,53 @@ def test_initialize_encryption_requires_crypto(monkeypatch, tmp_path):
     storage_path = tmp_path / "tokens.json"
 
     with pytest.raises(RuntimeError):
+        PersistentTokenStore(storage_path=storage_path, encrypt_at_rest=True)
+
+
+def test_invalid_encryption_key_with_persistence_raises(monkeypatch, tmp_path):
+    """A bad AMAZON_ADS_ENCRYPTION_KEY must not silently fall back when
+    persistence is enabled — previously persisted tokens would be
+    unreadable."""
+    monkeypatch.setenv("AMAZON_ADS_ENCRYPTION_KEY", "not-a-valid-fernet-key")
+    monkeypatch.setenv("AMAZON_ADS_TOKEN_PERSIST", "true")
+
+    storage_path = tmp_path / "tokens.json"
+    with pytest.raises(RuntimeError, match="Invalid AMAZON_ADS_ENCRYPTION_KEY"):
+        PersistentTokenStore(storage_path=storage_path, encrypt_at_rest=True)
+
+
+def test_invalid_encryption_key_without_persistence_disables_cipher(
+    monkeypatch, tmp_path
+):
+    """With persistence disabled, an invalid key should log an error and
+    disable encryption for the session rather than hard-failing."""
+    monkeypatch.setenv("AMAZON_ADS_ENCRYPTION_KEY", "not-a-valid-fernet-key")
+    monkeypatch.setenv("AMAZON_ADS_TOKEN_PERSIST", "false")
+
+    storage_path = tmp_path / "tokens.json"
+    store = PersistentTokenStore(storage_path=storage_path, encrypt_at_rest=True)
+
+    assert store._cipher is None
+
+
+def test_decrypt_failure_raises_typed_error(monkeypatch, tmp_path):
+    """Decryption failures must surface as TokenStoreDecryptError, not
+    silently return an empty dict."""
+    import json
+
+    # Encrypt a payload under key A
+    key_a = Fernet.generate_key().decode("ascii")
+    monkeypatch.setenv("AMAZON_ADS_ENCRYPTION_KEY", key_a)
+
+    storage_path = tmp_path / "tokens.json"
+    store_a = PersistentTokenStore(storage_path=storage_path, encrypt_at_rest=True)
+    payload = store_a._encrypt_data({"some": "payload"})
+    storage_path.write_text(json.dumps(payload))
+
+    # Swap to key B and attempt to load: must raise the typed error rather
+    # than silently behave like a fresh store.
+    key_b = Fernet.generate_key().decode("ascii")
+    monkeypatch.setenv("AMAZON_ADS_ENCRYPTION_KEY", key_b)
+
+    with pytest.raises(TokenStoreDecryptError):
         PersistentTokenStore(storage_path=storage_path, encrypt_at_rest=True)


### PR DESCRIPTION
## Summary

Five focused commits addressing security and correctness issues surfaced in the code review. Each commit is self-contained, independently revertable, and ships with targeted tests.

### Commits

1. **`fix: contain download tool paths to active profile`** (`73520f8`)
   - New shared `safe_join_within` helper in `utils/paths.py`.
   - `get_download_url_tool`, `get_download_metadata`, and `_validate_file_access` all resolve user-supplied paths relative to the active profile and reject absolute paths, `..` components, and symlink escapes.
   - `get_download_metadata` now **requires** `profile_id` (breaking for direct callers of that internal helper).

2. **`fix: stream export downloads with enforced size cap`** (`89de04e`)
   - `ExportDownloadHandler.download_export` now streams via `httpx.AsyncClient.stream` + `aiter_bytes`, enforces `AMAZON_ADS_DOWNLOAD_MAX_FILE_SIZE` from both the `Content-Length` header and during streaming, and runs blocking file / gzip work in `asyncio.to_thread`.
   - `.meta.json` stores `original_url_sha256` instead of the pre-signed URL, so pre-signed tokens no longer rest on disk.
   - New typed `DownloadTooLargeError` in `utils/errors.py`.

3. **`fix: coalesce token refresh, correct circuit breaker accounting, re-inject auth on retry`** (`49aeae6`)
   - Per-identity `asyncio.Lock` in `AuthManager`, per-provider locks in Direct and Openbridge providers. Concurrent token-refresh requests now coalesce into a single upstream call (double-checked locking inside the lock).
   - `ResilientRetry` records circuit-breaker failures **once per logical request**, not per retry attempt.
   - `AuthenticatedClient.send` re-injects auth headers on every send so retries pick up freshly refreshed tokens.

4. **`fix(auth): harden encryption key validation, OAuth HMAC, and fail-closed middleware`** (`e1df81e`)
   - Invalid `AMAZON_ADS_ENCRYPTION_KEY` with `AMAZON_ADS_TOKEN_PERSIST=true` now raises at startup instead of silently generating a random key that would orphan previously persisted tokens.
   - `_decrypt_data` failures surface as typed `TokenStoreDecryptError` instead of returning `{}` (which looked identical to a fresh install).
   - OAuth state HMAC uses the full 256-bit SHA-256 digest instead of a truncated 64-bit prefix.
   - `RefreshTokenMiddleware` fails closed on unexpected errors: auth setup exceptions now reject the request with `ToolError` rather than passing through to tools with a stale/missing identity.

5. **`fix(server): safer public URL resolution, configurable OAuth redirect, real /health version`** (`033cef8`)
   - `OAuthTools` now honors `OAUTH_REDIRECT_URI` (required for non-localhost deployments to match Amazon's registered callback).
   - `_get_base_url` resolution order is now `AMAZON_ADS_PUBLIC_BASE_URL` > `X-Forwarded-*` (only if `AMAZON_ADS_TRUST_FORWARDED_HEADERS=true`) > `request.base_url`. Closes a URL-forgery vector where any HTTP client could forge download URLs pointing at a controlled host.
   - `/health` reports the actual package version from `amazon_ads_mcp.__version__` instead of the hardcoded `"1.0.0"` placeholder.
   - Documents the new environment variables in `AGENTS.md` / `CLAUDE.md`.

## Migration notes

- **Required env for non-localhost deployments**: set `AMAZON_ADS_PUBLIC_BASE_URL` (and `OAUTH_REDIRECT_URI` if using OAuth). Without these, download URLs and OAuth callbacks fall back to `request.base_url` / `http://localhost:<port>`.
- **`AMAZON_ADS_TRUST_FORWARDED_HEADERS` now defaults to `false`**. Operators behind a trusted proxy that previously relied on `X-Forwarded-*` must set this to `true` explicitly.
- **Invalid `AMAZON_ADS_ENCRYPTION_KEY` with persistence enabled is now a hard startup failure**. Intentional — the previous silent fallback would have made any already-persisted tokens unrecoverable.
- **Persisted token store decryption failures now raise `TokenStoreDecryptError`** at startup instead of silently discarding state. Rotate the key back or delete the persisted file intentionally.
- **OAuth state HMAC is now 64 hex chars (full SHA-256)**. Any OAuth authorization flows already in-flight at the moment of deploy will fail validation on callback and must be retried. TTL is 10 minutes, so blast radius is small.
- **Internal API**: `get_download_metadata(file_path)` now requires `profile_id`.

## Test plan

- [x] `uv run ruff check --fix` — clean
- [x] Targeted new tests per commit:
  - `tests/unit/test_download_paths.py`
  - `tests/unit/test_export_download_handler.py` (rewritten for streaming)
  - `tests/unit/test_auth_refresh_singleflight.py`
  - `tests/unit/test_resilience_circuit_breaker.py`
  - `tests/unit/test_http_client_retry_auth.py`
  - `tests/unit/test_oauth_state_store.py`
  - `tests/unit/test_health_endpoint_version.py`
  - updates to `test_token_store.py`, `test_authentication_middleware.py`, `test_file_routes.py`, `test_oauth_tools.py`, `test_download_tools.py`
- [x] `uv run pytest` — **431 passed, 1 skipped**, plus 2 pre-existing failures unrelated to this PR (`TestInMemoryMCPOperations::test_list_tools_returns_builtin_tools` and `TestInMemoryToolDiscovery::test_tool_has_description`; both fail identically on `main` before this branch, appear to be a `CODE_MODE` / environment mismatch in that test harness).

## Risk / rollback

- All 5 commits are independent; any one can be reverted without stacking reverts.
- Highest-blast-radius change is the fail-closed auth middleware: any deployment that previously relied on silent passthrough when auth pre-processing errored will now see `ToolError` until the underlying error is fixed. This is intentional and matches the security posture most operators expect.
- HMAC widening (commit 4) invalidates in-flight OAuth state tokens at deploy time; 10 min TTL caps impact.
- Streamed-download change (commit 2) converts previously-OOM-prone large downloads into a clean `DownloadTooLargeError`, bounded by `AMAZON_ADS_DOWNLOAD_MAX_FILE_SIZE`.

## Out of scope (left for follow-ups)

- Consolidating `PersistentTokenStore` and `SecureTokenStore` into one path
- Async-native token store I/O beyond the hot paths covered here
- CORS narrowing / log-level downgrade sweep outside the files above
- CI additions (ruff/mypy/pip-audit)
- Base64 padding fix, `set_active_region` → `set_region` rename, `require_any_of` correctness — noted as a separate "quick wins" PR