### PR TITLE
fix(auth): hydrate Direct auth session state and surface env refresh …

### DIFF
--- a/src/amazon_ads_mcp/server/server_builder.py
+++ b/src/amazon_ads_mcp/server/server_builder.py
@@ -16,6 +16,7 @@ from .. import __version__
 from ..auth.manager import get_auth_manager
 from ..config.settings import settings
 from ..middleware.authentication import (
+    AuthSessionStateMiddleware,
     create_auth_middleware,
     create_openbridge_config,
 )
@@ -212,8 +213,19 @@ class ServerBuilder:
                 middleware_list.append(sampling_middleware)
             logger.info("Added server-side sampling middleware")
 
-        # Add OpenBridge middleware if using OpenBridge auth
+        # Bridge ContextVar auth state with FastMCP session state for all
+        # providers. Tool calls may cross async contexts within the same MCP
+        # session; without this, Direct+HTTP loses identity/credentials/profile
+        # ContextVars between calls. OpenBridge gets the same middleware via
+        # create_auth_middleware below, so skip adding it twice.
         provider_type = getattr(self.auth_manager.provider, "provider_type", None)
+        if provider_type != "openbridge":
+            middleware_list.append(AuthSessionStateMiddleware())
+            logger.info(
+                "Added AuthSessionStateMiddleware for %s auth", provider_type or "unknown"
+            )
+
+        # Add OpenBridge middleware if using OpenBridge auth
         if provider_type == "openbridge":
             ob_config = create_openbridge_config()
             auth_middlewares = create_auth_middleware(

--- a/src/amazon_ads_mcp/tools/oauth.py
+++ b/src/amazon_ads_mcp/tools/oauth.py
@@ -184,6 +184,27 @@ class OAuthTools:
             except Exception as e:
                 logger.debug(f"Could not check auth manager: {e}")
 
+        # Last resort: env-configured Direct auth (AMAZON_AD_API_REFRESH_TOKEN
+        # or legacy amazon_ads_refresh_token). Read the underlying fields to
+        # avoid Settings.effective_refresh_token's DeprecationWarning on every
+        # status poll.
+        if not tokens_data:
+            try:
+                env_refresh = (
+                    getattr(self.settings, "ad_api_refresh_token", None)
+                    or getattr(self.settings, "amazon_ads_refresh_token", None)
+                )
+                if env_refresh:
+                    tokens_data = {
+                        "refresh_token": env_refresh,
+                        "access_token": "",
+                        "expires_in": 0,
+                        "obtained_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    await ctx.set_state("oauth_tokens", tokens_data)
+            except Exception as e:
+                logger.debug(f"Could not read env refresh token: {e}")
+
         # Check if callback has been received (legacy path)
         if hasattr(self, "_callback_tokens"):
             tokens = self._callback_tokens


### PR DESCRIPTION
…token in OAuth status

Attach AuthSessionStateMiddleware for all providers (not just OpenBridge) so Direct+HTTP preserves identity/credentials/profile ContextVars across tool calls within the same MCP session. OpenBridge continues to receive the middleware via create_auth_middleware; skip double-adding it.

Add a final fallback in OAuthTools.check_oauth_status that reads ad_api_refresh_token / amazon_ads_refresh_token off settings, so env-configured Direct auth is reported as active alongside the existing context, secure-store, and auth-manager checks. Read the underlying fields directly to avoid Settings.effective_refresh_token's DeprecationWarning on every status poll.

