### PR TITLE
fix(http): apply per-operation vendored media types to Accept header

### DIFF
--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -505,13 +505,30 @@ class AuthenticatedClient(httpx.AsyncClient):
             content_type, accepts = self.media_registry.resolve(method, url)
             if content_type and method.lower() != "get":
                 request.headers["Content-Type"] = content_type
-            # Respect pre-existing Accept header from upstream transforms/tools
-            if accepts and "Accept" not in request.headers:
+            if accepts:
                 preferred = next(
                     (a for a in accepts if a.startswith("application/vnd.")),
                     accepts[0],
                 )
-                request.headers["Accept"] = preferred
+                existing = (request.headers.get("Accept") or "").strip()
+                # Amazon's v3 gateway strictly enforces per-operation media
+                # types. Override generic fallbacks (missing, "*/*",
+                # non-vendored) with the spec-declared vendored type when
+                # one exists. httpx defaults Accept to "*/*", which the
+                # previous "not in headers" guard treated as caller-set
+                # and skipped — causing 415s on SP v3 + TPG v1 endpoints.
+                # Respect callers who explicitly pass a vendored Accept
+                # (e.g. pinning TargetPromotionGroups v2).
+                should_override = (
+                    not existing
+                    or existing == "*/*"
+                    or (
+                        preferred.startswith("application/vnd.")
+                        and not existing.startswith("application/vnd.")
+                    )
+                )
+                if should_override:
+                    request.headers["Accept"] = preferred
 
         # Heuristic Accept override for known download/report endpoints
         if (

--- a/tests/unit/test_client_accept_resolver.py
+++ b/tests/unit/test_client_accept_resolver.py
@@ -4,10 +4,13 @@ This module tests the accept header resolution functionality
 in the authenticated client for different API endpoints.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
 import pytest
 
 from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+from amazon_ads_mcp.utils.media import MediaTypeRegistry
 
 
 @pytest.mark.asyncio
@@ -46,3 +49,121 @@ async def test_explicit_accept_header_is_respected(monkeypatch):
         await c.send(req)
 
     assert captured.get("accept") == "text/vnd.measurementresult.v1.2+csv"
+
+
+@pytest.mark.asyncio
+async def test_httpx_default_accept_is_overridden_with_vendored_type():
+    """Regression: httpx defaults Accept to "*/*"; the media registry's
+    vendored Accept must replace it. Previously the "Accept not in headers"
+    guard treated "*/*" as caller-set and skipped the override, causing
+    HTTP 415 on Sponsored Products v3 and Target Promotion Groups v1
+    endpoints.
+    """
+    auth_manager = AsyncMock()
+    auth_manager.get_headers = AsyncMock(
+        return_value={"Authorization": "Bearer test"}
+    )
+    auth_manager.provider = MagicMock()
+    auth_manager.provider.requires_identity_region_routing = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.headers_are_identity_specific = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.region_controlled_by_identity = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.provider_type = "direct"
+    auth_manager.get_active_identity = MagicMock(return_value=None)
+
+    registry = MagicMock(spec=MediaTypeRegistry)
+    registry.resolve = MagicMock(
+        return_value=(
+            "application/vnd.spCampaign.v3+json",
+            ["application/vnd.spCampaign.v3+json"],
+        )
+    )
+
+    client = AuthenticatedClient(
+        auth_manager=auth_manager,
+        media_registry=registry,
+    )
+
+    # Build a request via the client itself so httpx's default
+    # Accept: */* is present, mirroring the real upstream call path.
+    request = client.build_request(
+        "POST",
+        "https://advertising-api-eu.amazon.com/sp/campaigns/list",
+        json={"stateFilter": {"include": ["ENABLED"]}},
+    )
+    assert request.headers.get("accept") == "*/*"
+
+    with patch.object(
+        httpx.AsyncClient, "send", new_callable=AsyncMock
+    ) as mock_send:
+        mock_send.return_value = httpx.Response(200, request=request)
+        await client.send(request)
+
+    sent = mock_send.call_args[0][0]
+    assert sent.headers.get("accept") == "application/vnd.spCampaign.v3+json"
+    assert (
+        sent.headers.get("content-type") == "application/vnd.spCampaign.v3+json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_vendored_accept_is_preserved():
+    """Callers pinning a specific vendored Accept (e.g. TPG v2) must not
+    be overridden by the registry's first-listed vendored type.
+    """
+    auth_manager = AsyncMock()
+    auth_manager.get_headers = AsyncMock(
+        return_value={"Authorization": "Bearer test"}
+    )
+    auth_manager.provider = MagicMock()
+    auth_manager.provider.requires_identity_region_routing = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.headers_are_identity_specific = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.region_controlled_by_identity = MagicMock(
+        return_value=False
+    )
+    auth_manager.provider.provider_type = "direct"
+    auth_manager.get_active_identity = MagicMock(return_value=None)
+
+    registry = MagicMock(spec=MediaTypeRegistry)
+    registry.resolve = MagicMock(
+        return_value=(
+            "application/vnd.sptargetpromotiongroup.v1+json",
+            [
+                "application/vnd.sptargetpromotiongroup.v1+json",
+                "application/vnd.sptargetpromotiongroup.v2+json",
+            ],
+        )
+    )
+
+    client = AuthenticatedClient(
+        auth_manager=auth_manager,
+        media_registry=registry,
+    )
+
+    request = client.build_request(
+        "POST",
+        "https://advertising-api-eu.amazon.com/sp/targetPromotionGroups",
+        headers={"Accept": "application/vnd.sptargetpromotiongroup.v2+json"},
+        json={},
+    )
+
+    with patch.object(
+        httpx.AsyncClient, "send", new_callable=AsyncMock
+    ) as mock_send:
+        mock_send.return_value = httpx.Response(200, request=request)
+        await client.send(request)
+
+    sent = mock_send.call_args[0][0]
+    assert (
+        sent.headers.get("accept")
+        == "application/vnd.sptargetpromotiongroup.v2+json"
+    )


### PR DESCRIPTION
Amazon's gateway strictly enforces per-operation Accept headers for Sponsored Products v3 entity endpoints and Target Promotion Groups v1 endpoints. Calling these with Accept: */* returns HTTP 415 Unsupported Media Type, which has been blocking 36 SP v3 CRUD tools plus 4 Target Promotion Groups tools.

The MediaTypeRegistry already extracts vendored media types from each operation's requestBody.content / responses.*.content in the OpenAPI specs and exposes them via resolve(method, url). The bug was in AuthenticatedClient._inject_headers: the override of Accept was guarded by `if accepts and "Accept" not in request.headers`, but httpx's client.build_request(...) injects Accept: */* by default, so the guard treated the default fallback as a caller-set Accept and skipped the override. Content-Type was already overridden unconditionally for non-GET requests, so only Accept needed fixing.

Bugs resolved
- SP v3 entity CRUD (36 tools): campaigns, ad groups, keywords, product ads, negative keywords, campaign negative keywords, targeting clauses, negative targeting clauses, campaign negative targeting clauses
- Target Promotion Groups v1 (4 tools): list/create for groups and group-targets

Root cause
- httpx default Accept: */* defeated the existing media-registry override guard at src/amazon_ads_mcp/utils/http_client.py.

Fix scope
- Narrow override of Accept when the existing value is missing, "*/*", or non-vendored while the registry has a vendored type.
- Content-Type path unchanged (was already correct).
- Callers pinning a specific vendored Accept (e.g. TPG v2) are preserved.

Verification
- 11/11 fix-target tools returned HTTP 200 from advertising-api-eu.amazon.com (live wire log) against profile 2535915789117409 with stateFilter ENABLED.
- 576/577 unit tests green. Single pre-existing failure (test_ensure_ascii_false_preserves_unicode) is a Windows codepage issue in the test source file, unrelated to this change.
- Two new regression tests added covering (a) httpx default Accept */* getting replaced with the vendored type and (b) caller-pinned vendored Accept being preserved.

Known follow-ups, out of scope for this PR
- MediaTypeRegistry picks the first content type listed in the spec when multiple versioned vendored types are declared. For sp_getRankedKeywordRecommendation this picks v3 while Amazon's current request shape expects v5, producing a pre-existing 500 unrelated to the 415 fix. Worth teaching the registry to prefer the highest vN+json when the spec declares several.
- The *.media.json sidecar files in dist/openapi/resources/ ship as {version, namespace, content_types: [<flat list>]} but MediaTypeRegistry.add_from_sidecar expects {requests: {METHOD path: type}, responses: {METHOD path: type}}. As shipped, the sidecars are dead data; resolution falls through to add_from_spec which works correctly.