### PR TITLE
fix(http): unify Accept-header resolver, prefer highest vN+json (closes #70)

### DIFF
--- a/docs/roadmap/unified-accept-resolver.md
+++ b/docs/roadmap/unified-accept-resolver.md
@@ -14,6 +14,15 @@ PR #68 fixed the immediate 415 errors on Sponsored Products v3 entity CRUD (36 t
 
 This roadmap item is the principled refactor that consolidates Accept resolution into one testable surface AND fixes the multi-version bug at the same time. PR #68's wire contract is preserved; only the internal shape changes.
 
+## Design discipline
+
+**Spec-driven, not hand-curated.** New helpers must justify why the OpenAPI spec can't drive the behavior.
+
+- **Build-time decomposition of spec data is spec-driven.** Splitting one spec into `<ns>.json` (paths/schemas), `<ns>.media.json` (per-op content types), `<ns>.manifest.json`, and `<ns>.transform.json` (genuinely spec-orphaned overrides) is not a wrapper — it's the same spec data, partitioned for context efficiency. Generators read the canonical spec; loaders consume the partitions.
+- **Hand-curated per-operation overrides are not spec-driven.** A `transform.json.accept_override` field that names specific operationIds and pins specific versions would create maintenance debt and break silently when Amazon renames operations or ships new versions. Rejected.
+- **The runtime resolver picks "highest declared version"** as a spec-driven heuristic. If a tool genuinely needs a specific version, it pins Accept at the call site (preserved by PR #68's caller-pinned contract) — the requirement lives where it's known, not in a side file where it goes stale.
+- **`transform.json` carries only what the spec genuinely cannot express** — pagination param names, batch behavior, output projections, arg_aliases for fields that resist clean OpenAPI representation. Accept resolution does NOT belong there because the spec already declares which versions exist.
+
 ## Motivating examples (from `dist/openapi/resources/SponsoredProducts.json`)
 
 Operations that declare more than one versioned vendored content type today (extracted from the spec, not invented):
@@ -51,7 +60,7 @@ For all of these, `MediaTypeRegistry.resolve(method, url)` returns an `accepts` 
 - No change to `build_media_maps_from_spec` extraction logic — the resolver consumes what the registry already exposes.
 - No change to download endpoint semantics — `resolve_download_accept_headers` keeps its current contract.
 - No change to header-resolver (`HeaderNameResolver`) — it doesn't touch Accept.
-- No `*.media.json` sidecar work (that's a separate dead-data issue PR #68's author flagged; track it elsewhere).
+- No `*.media.json` sidecar work in PR 1 (resolver). Sidecar restoration is Phase 2 (separate PR after PR 1 lands) — see "Phase 2: Media sidecar restoration" below.
 
 ## Proposed shape
 
@@ -257,6 +266,12 @@ Pure-function tests, no httpx mocking. Each row is one assertion:
 
 These exercise the full `AuthenticatedClient.send` path with a mocked `MediaTypeRegistry`. They lock the wire contract PR #68 shipped. The refactor must not change their assertions. If we need to update the mocks because the resolver moved, that's fine — assertions stay identical.
 
+### Source-agnosticism guarantee (PR 1 acceptance criterion)
+
+The resolver must make zero assumptions about how the registry was populated. All pure-function unit tests inject `accepts` directly as a list of strings; no test depends on whether the data came from `MediaTypeRegistry.add_from_spec(spec)` or `MediaTypeRegistry.add_from_sidecar(sidecar)`. This guarantee is what makes Phase 1 (resolver) and Phase 2 (sidecar restoration) independent — the resolver works against either data source, and Phase 2 can land later without resolver changes.
+
+Test setup convention: pass `spec_accepts` as an explicit list literal in every unit test. Do NOT instantiate `MediaTypeRegistry` in resolver unit tests. The integration test below is the only place where the resolver runs against a real registry, and that test is allowed to source data from `add_from_spec` (today) or `add_from_sidecar` (post-Phase 2) — the assertions are the same either way.
+
 ### New integration test against real spec data
 
 `tests/unit/test_accept_resolver_against_spec.py` — loads `dist/openapi/resources/SponsoredProducts.json`, builds a real `MediaTypeRegistry`, and asserts:
@@ -332,8 +347,31 @@ No version bump triggered by this alone (it's a `fix:` per Conventional Commits,
 
 4. **`Content-Type` parity.** PR #68 only patched Accept. `MediaTypeRegistry.resolve` returns `content_type` as a single string (already-picked first via `sorted(rb_content.keys())[0]` at `utils/media/types.py:201`), not a list. Re-scan `dist/openapi/resources/` for any operation whose `requestBody.content` declares more than one vendored content type. If any exist with multi-version, expand the resolver to cover Content-Type with the same algorithm and add a Content-Type write inside `resolve_accept` (or a sibling). Likely none exist — most Amazon Ads operations request a single Content-Type even when they offer multiple response media types — but verify before locking the implementation.
 
+## Phase 2: Media sidecar restoration (separate PR, after PR 1 lands)
+
+The `*.media.json` sidecars exist as part of the build-time decomposition strategy that splits each spec into smaller artifacts for context efficiency. Today the strategy is half-implemented: the generator emits the wrong shape (`{namespace, content_types: [flat union]}`) and the loader calls `add_from_spec(media_spec)` instead of `add_from_sidecar(media_spec)`, so the sidecar contributes zero data and routing only works because `add_from_spec(spec)` is called separately on the unslimmed spec. The moment slimming strips response content from the spec, routing breaks.
+
+This is a fix-in-place, not a deletion. Sidecar restoration is fully spec-driven (the sidecar is build-time generated from the canonical spec, just decomposed) and is the precondition for future aggressive spec slimming.
+
+**PR 2 acceptance criteria:**
+
+1. **Generator** (`.build/scripts/process_openapi_specs.py:generate_media_sidecar`) rewritten to emit per-operation shape matching the contract `MediaTypeRegistry.add_from_sidecar()` already accepts:
+   ```json
+   {
+     "version": "1.0",
+     "namespace": "SponsoredProducts",
+     "requests": {"POST /sp/campaigns/list": "application/vnd.spCampaign.v3+json", ...},
+     "responses": {"POST /sp/campaigns/list": ["application/vnd.spCampaign.v3+json", ...], ...}
+   }
+   ```
+2. **Loader** (`server_builder.py:638`) switches from `add_from_spec(media_spec)` to `add_from_sidecar(media_spec)`. The redundant `add_from_spec(spec)` call directly above can be left in place during PR 2 (both paths populate the registry); evaluate removal in a follow-up only when slimming is actually enabled.
+3. **Parity test suite (the drift guardrail).** For each spec in `dist/openapi/resources/`, build two registries — one populated from the spec only via `add_from_spec(spec)`, one populated from the sidecar only via `add_from_sidecar(media_spec)` — and assert `resolve(method, url)` returns identical `(content_type, accepts)` for every operation in the spec. Catches: generator drift, loader bugs, regression in either pipeline. This is the single test that prevents the two halves from drifting again.
+4. **No new sidecar consumers.** Phase 2 fixes the existing consumer; it does not add new ones. If a future spec-slimming PR strips response content from runtime specs, the existing sidecar consumer continues to work because its data is already populated at startup.
+
+**(b)-fallback condition.** If aggressive slimming (e.g. `SLIM_OPENAPI_AGGRESSIVE=true` or `SLIM_OPENAPI_STRIP_RESPONSES=true` becoming default) is about to be enabled in the same release window as PR 1, flip the order: ship sidecar restoration first so the resolver lands on a clean data layer. As of this writing the slimming env vars are off by default (per CLAUDE.md), so order (a) — resolver first, sidecar second — is the faster and still safe path.
+
 ## Out of scope (track separately)
 
-- Dead `*.media.json` sidecar files in `dist/openapi/resources/` (PR #68 author flagged the shape mismatch with `MediaTypeRegistry.add_from_sidecar`). Open a separate cleanup issue.
 - Cross-server error envelope contract work (separate roadmap, separate branch).
 - Code Mode-side surfacing of the new resolver decisions (none needed; resolver runs at the transport layer below code mode).
+- Aggressive spec slimming follow-up. Once Phase 2 lands and parity tests are green, a separate PR can strip response content from runtime specs to claim the context-bloat win that motivated the sidecar split in the first place. Track as its own roadmap item.

--- a/docs/roadmap/unified-accept-resolver.md
+++ b/docs/roadmap/unified-accept-resolver.md
@@ -9,7 +9,7 @@
 PR #68 fixed the immediate 415 errors on Sponsored Products v3 entity CRUD (36 tools) and Target Promotion Groups v1 (4 tools) by extending the Accept-override guard in `AuthenticatedClient._inject_headers` to also fire when the existing Accept value is `*/*` or non-vendored. That fix is correct in scope, but it leaves three architectural smells in `_inject_headers`:
 
 1. **Two parallel Accept-resolution blocks** at `http_client.py:520-557`. The media-registry block (lines 521-549) and the download/report heuristic block (lines 551-577) each duplicate the `*/*` discrimination and "prefer vendored" logic. After PR #68 both blocks check for `*/*` and both can write to `request.headers["Accept"]`.
-2. **"First vendored from list" picker is hardcoded** at `http_client.py:528-531`: `next((a for a in accepts if a.startswith("application/vnd.")), accepts[0])`. When the OpenAPI operation declares multiple versioned vendored types (e.g. `v3`, `v4`, `v5`), the registry preserves spec ordering so the first listed wins. PR #68 explicitly flags this as the reason `sp_getRankedKeywordRecommendation` resolves to `v3+json` while Amazon's current request shape expects `v5+json`, producing a pre-existing 500 unrelated to the 415 fix.
+2. **"First vendored from list" picker is hardcoded** at `http_client.py:528-531`: `next((a for a in accepts if a.startswith("application/vnd.")), accepts[0])`. When the OpenAPI operation declares multiple versioned vendored types (e.g. `v3`, `v4`, `v5`), the registry returns them lexically sorted (single-digit versions sort numerically by coincidence), so the first vendored entry is `v3+json`. PR #68 explicitly flags this as the reason `sp_getRankedKeywordRecommendation` resolves to `v3+json` while Amazon's current request shape expects `v5+json`, producing a pre-existing 500 unrelated to the 415 fix.
 3. **Policy buried in transport boolean logic.** PR #68's `should_override` is a four-clause boolean. There is no test for the "non-vendored existing → upgrade to vendored" path (the most controversial of the four). The decision lives implicitly in a single line of `_inject_headers` rather than in a documented resolver.
 
 This roadmap item is the principled refactor that consolidates Accept resolution into one testable surface AND fixes the multi-version bug at the same time. PR #68's wire contract is preserved; only the internal shape changes.
@@ -29,12 +29,16 @@ Operations that declare more than one versioned vendored content type today (ext
 | `CreateTargetPromotionGroups`, `ListTargetPromotionGroups` | `/sp/targetPromotionGroups[/list]` | `sptargetpromotiongroup` | 1, 2 |
 | `CreateTargetPromotionGroupTargets`, `ListTargetPromotionGroupTargets` | `/sp/targetPromotionGroups/targets[/list]` | `sptargetpromotiongrouptarget` | 1, 2 |
 
-For all of these, `MediaTypeRegistry.resolve(method, url)` returns an `accepts` list whose first vendored entry is whichever version the spec lists first. Today that is silently the lowest version, which is why `sp_getRankedKeywordRecommendation` 500s on Amazon's current shape. The TPG operations 200 today only because v1 and v2 happen to remain compatible — the same shape problem would bite the moment Amazon makes v2 the required version for a given request body.
+For all of these, `MediaTypeRegistry.resolve(method, url)` returns an `accepts` list — deduplicated and lexically sorted (see Registry contract below). The current picker takes the first vendored entry, which after lexical sort happens to be the lowest single-digit version (`v3` < `v4` < `v5`). That's why `sp_getRankedKeywordRecommendation` 500s on Amazon's current shape. The TPG operations 200 today only because v1 and v2 happen to remain compatible — the same shape problem would bite the moment Amazon makes v2 the required version for a given request body.
+
+## Registry contract
+
+`MediaTypeRegistry.resolve(method, url)` returns `accepts` as a deduplicated, lexically sorted list (see `utils/media/types.py:204-212` — `accepts: Set[str] = set()` then `resp_media[…] = sorted(accepts)`). The resolver MUST NOT depend on input order. All version comparisons happen on parsed `(major, minor)` ints. Lexical sort is correct for single-digit versions but not for two-digit (`v10` lexically precedes `v9`); the parsed-int picker is order-independent and handles both.
 
 ## Goals
 
 1. **Single source of truth for Accept resolution.** Replace the two blocks in `_inject_headers` with one call into a pure resolver.
-2. **Prefer highest `vN+json` from spec-declared accepts** when multiple versions are present. Highest-major wins; on ties, highest-minor wins; on full ties, preserve spec order.
+2. **Prefer highest `vN[.M]+json` from spec-declared accepts** when multiple versions are present. Highest-major wins; on ties, highest-minor wins; full version duplicates are deduped by the registry upstream and never reach the picker.
 3. **Preserve PR #68's wire contract:**
    - Caller-pinned vendored Accept (e.g. tool explicitly sets `application/vnd.sptargetpromotiongroup.v2+json`) is never overridden.
    - Missing Accept, `*/*`, or non-vendored Accept gets upgraded to the highest spec-declared vendored type when one exists.
@@ -60,33 +64,44 @@ from typing import Iterable, Optional, Tuple
 import re
 
 # application/vnd.<base>.v<major>[.<minor>]+json
-_VENDORED_RE = re.compile(
-    r"^application/vnd\.([A-Za-z0-9]+)\.v(\d+)(?:\.(\d+))?\+json$"
+# Base allows alphanumerics, dots, hyphens, underscores — real specs use
+# compound bases like "spproductrecommendationresponse.asins" and
+# "SponsoredBrands.SponsoredBrandsMigrationApi".
+_VENDORED_JSON_RE = re.compile(
+    r"^application/vnd\.([A-Za-z0-9._-]+)\.v(\d+)(?:\.(\d+))?\+json$"
 )
 
 
-def parse_vendored(ct: str) -> Optional[Tuple[str, int, int]]:
+def parse_vendored_json(ct: str) -> Optional[Tuple[str, int, int]]:
     """Return (base, major, minor) for application/vnd.<base>.v<N>[.<M>]+json,
-    or None for any other content type. Minor defaults to 0."""
-    m = _VENDORED_RE.match(ct or "")
+    or None for any other content type (including text/vnd.*+csv variants
+    and bare application/vnd.<base>.v<N> with no +json suffix). Minor
+    defaults to 0. Base is lowercased for stable comparison."""
+    m = _VENDORED_JSON_RE.match(ct or "")
     if not m:
         return None
     return m.group(1).lower(), int(m.group(2)), int(m.group(3) or 0)
 
 
-def pick_highest_vendored(accepts: Iterable[str]) -> Optional[str]:
-    """Pick the highest vN[.M]+json from an ordered list. Ties keep spec order."""
-    best: Optional[Tuple[Tuple[int, int], int, str]] = None
-    for idx, ct in enumerate(accepts or ()):
-        parsed = parse_vendored(ct)
-        if not parsed:
-            continue
-        _, major, minor = parsed
-        # idx negated so earlier entries win on full version ties
-        key = ((major, minor), -idx)
-        if best is None or key > best[:2]:
-            best = (key[0], key[1], ct)
-    return best[2] if best else None
+def pick_highest_vendored_json(accepts: Iterable[str]) -> Optional[str]:
+    """Pick the highest vN[.M]+json from a list of content types.
+
+    When the list contains multiple distinct bases (rare but real — e.g. an
+    op declaring both spproductrecommendationresponse.asins and
+    spproductrecommendationresponse.themes), the picker abstains and returns
+    None. The caller cannot decide between bases without semantic context;
+    rule 4 of resolve_accept handles this by falling back to first-listed.
+
+    When only one base is present, return the highest (major, minor)."""
+    parsed = [(parse_vendored_json(ct), ct) for ct in (accepts or ())]
+    parsed = [(p, ct) for (p, ct) in parsed if p is not None]
+    if not parsed:
+        return None
+    bases = {p[0] for (p, _) in parsed}
+    if len(bases) > 1:
+        return None  # mixed bases — abstain, let caller fall back
+    best = max(parsed, key=lambda item: (item[0][1], item[0][2]))
+    return best[1]
 
 
 def resolve_accept(
@@ -99,17 +114,24 @@ def resolve_accept(
 
     Returns the new value, or None to leave the request's Accept unchanged.
 
-    Policy (in order):
+    Policy (in execution order — code below mirrors this exactly):
       1. Caller-pinned vendored Accept (existing starts with "application/vnd.")
-         is preserved — return None.
-      2. If spec_accepts contains a vendored type, pick the highest vN+json.
-         If existing is missing/"*/*"/non-vendored, return that.
-      3. If spec_accepts has no vendored type but has any value, fall back to
-         the first listed when existing is missing/"*/*".
-      4. If download_overrides intersects spec_accepts, prefer that intersection.
-         If no spec_accepts but existing is missing/"*/*", use overrides[0].
-      5. Otherwise return None (leave existing alone).
-    """
+         is preserved unconditionally — return None.
+      2. If download_overrides ∩ spec_accepts is non-empty AND existing is
+         missing / "*/*" / non-vendored — return the first overlapping value.
+         (Download endpoints declare a specific vendored type; that wins
+         over "highest vendored" because the download contract is more
+         specific than spec-listed alternatives.)
+      3. If spec_accepts contains vendored JSON of a single base, pick the
+         highest vN[.M]+json. Override existing when missing / "*/*" /
+         non-vendored.
+      4. If spec_accepts contains values but no single-base vendored JSON
+         (mixed bases, no JSON variants, or non-JSON vendored) — fall back
+         to first-listed when existing is missing / "*/*". Don't touch a
+         non-vendored caller value.
+      5. If only download_overrides exists (no spec_accepts) — return
+         overrides[0] when existing is missing / "*/*".
+      6. Otherwise return None (leave existing alone)."""
     existing_norm = (existing or "").strip()
     is_vendored_existing = existing_norm.startswith("application/vnd.")
 
@@ -117,28 +139,29 @@ def resolve_accept(
     if is_vendored_existing:
         return None
 
-    # Rule 4 (intersection branch): download overrides + spec accepts
+    # Rule 2: download_overrides ∩ spec_accepts (intersection wins over highest)
     if download_overrides and spec_accepts:
         for ct in download_overrides:
             if ct in spec_accepts:
                 if existing_norm in ("", "*/*") or not _is_vendored(existing_norm):
                     return ct
 
-    # Rule 2: highest vendored from spec
-    highest = pick_highest_vendored(spec_accepts or ())
+    # Rule 3: highest vendored JSON from spec (single base)
+    highest = pick_highest_vendored_json(spec_accepts or ())
     if highest and (
         existing_norm == "" or existing_norm == "*/*" or not _is_vendored(existing_norm)
     ):
         return highest
 
-    # Rule 3: spec accepts present but no vendored entry
+    # Rule 4: spec accepts present but no single-base vendored JSON
     if spec_accepts and (existing_norm == "" or existing_norm == "*/*"):
         return spec_accepts[0]
 
-    # Rule 4 (download-only branch): no spec accepts to intersect against
+    # Rule 5: download-only (no spec accepts)
     if download_overrides and (existing_norm == "" or existing_norm == "*/*"):
         return download_overrides[0]
 
+    # Rule 6: leave alone
     return None
 
 
@@ -176,17 +199,25 @@ That replaces lines 520-577 of the post-PR-68 `_inject_headers` (~58 lines) with
 
 ## Version-selection algorithm details
 
-`parse_vendored` and `pick_highest_vendored` need explicit edge-case behavior locked by tests:
+`parse_vendored_json` and `pick_highest_vendored_json` need explicit edge-case behavior locked by tests. All examples below are verified against current `dist/openapi/resources/`:
+
+**Parser behavior:**
 
 - `application/vnd.spkeywordsrecommendation.v3+json` → `(spkeywordsrecommendation, 3, 0)`
-- `application/vnd.measurementresult.v1.2+csv` → **not vendored JSON, returns None** (download resolver still handles CSV via `download_overrides`)
+- `application/vnd.spproductrecommendationresponse.asins.v3+json` → `(spproductrecommendationresponse.asins, 3, 0)` (dotted base, real type from SP spec)
+- `application/vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json` → `(sponsoredbrands.sponsoredbrandsmigrationapi, 4, 0)` (compound base, real type)
+- `text/vnd.measurementresult.v1.2+csv` → `None` (non-JSON, opaque to picker — download resolver still handles via `download_overrides`)
+- `application/vnd.GlobalRegistrationService.TermsTokenResource.v1` → `None` (no `+json` suffix — real type from a spec, intentionally rejected by the parser)
 - `application/vnd.insightsbrandmetrics.v1.1+json` → `(insightsbrandmetrics, 1, 1)`
-- Among `[v3+json, v4+json, v5+json]` → picks `v5+json`
-- Among `[v1.0+json, v1.2+json, v1.1+json]` → picks `v1.2+json`
-- Among `[v3+json, v3+json]` (duplicate listing) → picks first (spec order tie-break)
-- Mixed bases (e.g. an operation that lists `spfoo.v1+json` and `spbar.v2+json` in one operation) → picks highest version regardless of base. **This is rare and worth a contract test;** if real specs do this we need to defer to spec ordering instead.
 
-The tie-break choice (earlier index wins on full-tie) is intentional: when Amazon decides v3 is the right default and lists it first, we honor that.
+**Picker behavior:**
+
+- Among `[v3+json, v4+json, v5+json]` (single base) → picks `v5+json`
+- Among `[v1.0+json, v1.2+json, v1.1+json]` → picks `v1.2+json`
+- Among `[v1.99+json, v2.0+json]` → picks `v2.0+json` (major beats minor)
+- Multiple bases in one accepts list (e.g. `spproductrecommendationresponse.asins` + `…themes`) → picker abstains, returns `None`. `resolve_accept` rule 4 falls back to first-listed.
+
+Full version duplicates cannot reach the picker — `MediaTypeRegistry.add_from_spec` collapses via `set()` upstream (see Registry contract above). No tie-break logic is needed in the picker.
 
 ## Test matrix
 
@@ -203,18 +234,21 @@ Pure-function tests, no httpx mocking. Each row is one assertion:
 | Caller-pinned vendored | `["application/vnd.tpg.v1+json", "application/vnd.tpg.v2+json"]` | `"application/vnd.tpg.v2+json"` | None | None |
 | Caller-pinned vendored even when "wrong" | `["application/vnd.tpg.v2+json"]` | `"application/vnd.tpg.v1+json"` | None | None |
 | Multi-version: highest wins | `[v3, v4, v5]` | `"*/*"` | None | `v5+json` |
-| Multi-version: highest wins despite spec order | `[v5, v3, v4]` | `"*/*"` | None | `v5+json` |
+| Multi-version: highest wins regardless of input order | `[v5, v3, v4]` | `"*/*"` | None | `v5+json` (picker is order-independent on parsed `(major, minor)`) |
 | Major.minor: highest minor wins | `[v1.0, v1.2, v1.1]` | `"*/*"` | None | `v1.2+json` |
 | Major beats minor | `[v1.99, v2.0]` | `"*/*"` | None | `v2.0+json` |
-| Spec order tie-break on full version equality | `[v3+json, v3+json]` | `"*/*"` | None | first `v3+json` (id-stable) |
+| Dotted base parses correctly | `["application/vnd.spproductrecommendationresponse.asins.v3+json"]` | None | None | `vnd.spproductrecommendationresponse.asins.v3+json` |
+| Compound base with hyphen-like punctuation parses | `["application/vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json"]` | None | None | `vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json` |
+| Mixed dotted bases (single op declares two) | `["application/vnd.x.asins.v3+json", "application/vnd.x.themes.v3+json"]` | `"*/*"` | None | `vnd.x.asins.v3+json` (picker abstains, rule 4 first-listed; lexical sort already places `asins` before `themes`) |
+| Mixed bases with version difference | `["application/vnd.bar.v5+json", "application/vnd.foo.v3+json"]` | `"*/*"` | None | `vnd.bar.v5+json` (picker abstains; rule 4 first-listed after registry's lexical sort places `bar` before `foo`) |
 | No vendored in spec accepts, missing existing | `["application/json"]` | None | None | `"application/json"` |
-| Download override intersects spec | `["application/vnd.adsexport.v1+json", "application/json"]` | None | `["application/vnd.adsexport.v1+json"]` | `vnd.adsexport.v1+json` |
-| Download override doesn't intersect | `["application/vnd.spCampaign.v3+json"]` | `"*/*"` | `["text/csv"]` | `vnd.spCampaign.v3+json` (rule 2 wins) |
-| Download override only, no spec | None | `"*/*"` | `["text/csv"]` | `"text/csv"` |
+| Download override intersects spec | `["application/vnd.adsexport.v1+json", "application/json"]` | None | `["application/vnd.adsexport.v1+json"]` | `vnd.adsexport.v1+json` (rule 2 intersection) |
+| Download override doesn't intersect | `["application/vnd.spCampaign.v3+json"]` | `"*/*"` | `["text/csv"]` | `vnd.spCampaign.v3+json` (rule 3 wins) |
+| Download override only, no spec | None | `"*/*"` | `["text/csv"]` | `"text/csv"` (rule 5) |
 | Caller-pinned vendored + download override available | `["application/vnd.x.v1+json"]` | `"application/vnd.x.v1+json"` | `["application/json"]` | None (rule 1 absolute) |
 | Empty string Accept (whitespace) treated as missing | `["application/vnd.x.v1+json"]` | `"   "` | None | `vnd.x.v1+json` |
 | `*/*` with whitespace | `["application/vnd.x.v1+json"]` | `" */* "` | None | `vnd.x.v1+json` |
-| Non-JSON vendored ignored by `pick_highest_vendored` | `["application/vnd.measurementresult.v1.2+csv"]` | `"*/*"` | None | None or first-listed (decide and lock) |
+| Non-JSON vendored only, generic existing | `["text/vnd.measurementresult.v1.2+csv"]` | `"*/*"` | None | `"text/vnd.measurementresult.v1.2+csv"` (picker returns None, rule 4 first-listed; resolver stays neutral on non-JSON semantics) |
 
 ### PR #68 regression tests (preserved verbatim, must continue to pass)
 
@@ -227,18 +261,20 @@ These exercise the full `AuthenticatedClient.send` path with a mocked `MediaType
 
 `tests/unit/test_accept_resolver_against_spec.py` — loads `dist/openapi/resources/SponsoredProducts.json`, builds a real `MediaTypeRegistry`, and asserts:
 
-- `getRankedKeywordRecommendation` resolves to `application/vnd.spkeywordsrecommendation.v5+json` (the headline fix)
+- `getRankedKeywordRecommendation` resolves to `application/vnd.spkeywordsrecommendation.v5+json` (the headline fix; accepts list is `[v3+json, v4+json, v5+json]` after registry's lexical sort, single base, picker returns highest)
 - `GetThemeBasedBidRecommendationForAdGroup_v1` resolves to `v5+json`
 - `getTargetableCategories` resolves to `v5+json`
 - `getCategoryRecommendationsForASINs` resolves to `v5+json`
-- `getRefinementsForCategory` resolves to `v4+json`
+- `getRefinementsForCategory` resolves to `v4+json` (declared `[v3+json, v4+json]`)
 - `CreateTargetPromotionGroups` resolves to `v2+json` (was v1 pre-refactor)
 - All SP v3 entity CRUD operations resolve to `v3+json` (PR #68's contract — only one version declared, so highest is unchanged)
+- **Mixed-base guard test**: any operation in current spec that declares multiple bases in one accepts list resolves via rule 4 first-listed (picker abstains). At plan time, no SP operation does this — but the test should iterate every operation in the spec and assert that mixed-base ops fall through to first-listed without crashing. Catches the moment Amazon ships a multi-base operation.
 
 This test catches future regressions where:
 - A new spec introduces a v6 and we need to confirm we pick it up automatically.
 - Someone "fixes" the version logic in a way that breaks the spec contract.
-- The spec extraction in `build_media_maps_from_spec` changes shape.
+- The spec extraction in `build_media_maps_from_spec` changes shape (e.g. drops the lexical sort).
+- Amazon adds a multi-base accepts list and the mixed-base guard catches the silent abstention.
 
 ### Live-wire smoke (manual, not in CI)
 
@@ -284,12 +320,17 @@ This is a pure refactor of internal behavior with one intentional contract chang
 
 No version bump triggered by this alone (it's a `fix:` per Conventional Commits, patch bump only when merged).
 
-## Open questions to resolve during implementation
+## Open questions
 
-1. **Mixed-base accepts in one operation.** Does any current SponsoredProducts operation list two different `base` names in one accepts list? If yes, "highest version regardless of base" may be wrong; we'd need to bucket by base. Verify by extending the spec scan above.
-2. **Non-JSON vendored types.** `application/vnd.measurementresult.v1.2+csv` is a real declared type. Should `pick_highest_vendored` consider non-JSON, or strictly JSON? Current proposal: JSON-only. The CSV case stays in `download_overrides`. Lock the behavior in the test row marked "decide and lock".
-3. **`Content-Type` parity.** PR #68 only patched Accept. Do request bodies on multi-version operations also need a "highest vN+json" Content-Type? Current `MediaTypeRegistry.resolve` returns `req_map.get(...)` which is a single string, not a list, so the same picker doesn't apply directly. Worth a separate scan to confirm Content-Type is single-valued in every multi-version op; if not, expand the resolver.
-4. **`HeaderNameResolver` interaction.** Confirmed not touched by Accept. No work needed.
+**Resolved at plan time:**
+
+1. **Mixed-base accepts in one operation.** ✓ **Resolved.** Real and rare: SP spec declares both `spproductrecommendationresponse.asins` and `…themes` on the same operation. Locked behavior: `pick_highest_vendored_json` abstains (returns `None`) when more than one distinct base is present; `resolve_accept` rule 4 falls back to first-listed (after the registry's lexical sort). The implementer should NOT bucket by base and pick "highest per base" — that would require semantic context the resolver doesn't have. The `text/vnd.…+csv` case is also handled by abstention (parser returns None for non-JSON, picker returns None for empty parsed list, rule 4 returns first-listed).
+2. **Non-JSON vendored types.** ✓ **Resolved.** Picker is JSON-only by design (`_VENDORED_JSON_RE` requires `+json` suffix). Non-JSON vendored types (CSV via `text/vnd.…+csv`, bare-version variants without `+json`) are opaque to the picker and surface via rule 4's first-listed fallback. The `download_overrides` path remains the right place for endpoints that need explicit non-JSON Accept negotiation.
+3. **`HeaderNameResolver` interaction.** ✓ **Resolved.** `HeaderNameResolver` (`src/amazon_ads_mcp/utils/header_resolver.py`) only handles client/scope/account header NAMES. Does not touch Accept. No work needed.
+
+**Still open — implementer TODO before writing code:**
+
+4. **`Content-Type` parity.** PR #68 only patched Accept. `MediaTypeRegistry.resolve` returns `content_type` as a single string (already-picked first via `sorted(rb_content.keys())[0]` at `utils/media/types.py:201`), not a list. Re-scan `dist/openapi/resources/` for any operation whose `requestBody.content` declares more than one vendored content type. If any exist with multi-version, expand the resolver to cover Content-Type with the same algorithm and add a Content-Type write inside `resolve_accept` (or a sibling). Likely none exist — most Amazon Ads operations request a single Content-Type even when they offer multiple response media types — but verify before locking the implementation.
 
 ## Out of scope (track separately)
 

--- a/docs/roadmap/unified-accept-resolver.md
+++ b/docs/roadmap/unified-accept-resolver.md
@@ -1,0 +1,298 @@
+# Unified Accept-Header Resolver
+
+**Priority:** High value, medium urgency
+**Scope:** `src/amazon_ads_mcp/utils/http_client.py`, `src/amazon_ads_mcp/utils/media/` (new module), `src/amazon_ads_mcp/utils/export_content_type_resolver.py`
+**Follows:** PR #68 (`fix(http): apply per-operation vendored media types to Accept header`)
+
+## Context
+
+PR #68 fixed the immediate 415 errors on Sponsored Products v3 entity CRUD (36 tools) and Target Promotion Groups v1 (4 tools) by extending the Accept-override guard in `AuthenticatedClient._inject_headers` to also fire when the existing Accept value is `*/*` or non-vendored. That fix is correct in scope, but it leaves three architectural smells in `_inject_headers`:
+
+1. **Two parallel Accept-resolution blocks** at `http_client.py:520-557`. The media-registry block (lines 521-549) and the download/report heuristic block (lines 551-577) each duplicate the `*/*` discrimination and "prefer vendored" logic. After PR #68 both blocks check for `*/*` and both can write to `request.headers["Accept"]`.
+2. **"First vendored from list" picker is hardcoded** at `http_client.py:528-531`: `next((a for a in accepts if a.startswith("application/vnd.")), accepts[0])`. When the OpenAPI operation declares multiple versioned vendored types (e.g. `v3`, `v4`, `v5`), the registry preserves spec ordering so the first listed wins. PR #68 explicitly flags this as the reason `sp_getRankedKeywordRecommendation` resolves to `v3+json` while Amazon's current request shape expects `v5+json`, producing a pre-existing 500 unrelated to the 415 fix.
+3. **Policy buried in transport boolean logic.** PR #68's `should_override` is a four-clause boolean. There is no test for the "non-vendored existing → upgrade to vendored" path (the most controversial of the four). The decision lives implicitly in a single line of `_inject_headers` rather than in a documented resolver.
+
+This roadmap item is the principled refactor that consolidates Accept resolution into one testable surface AND fixes the multi-version bug at the same time. PR #68's wire contract is preserved; only the internal shape changes.
+
+## Motivating examples (from `dist/openapi/resources/SponsoredProducts.json`)
+
+Operations that declare more than one versioned vendored content type today (extracted from the spec, not invented):
+
+| Operation | Method + path | base | versions declared |
+|---|---|---|---|
+| `getRankedKeywordRecommendation` | `POST /sp/targets/keywords/recommendations` | `spkeywordsrecommendation` | 3, 4, 5 |
+| `GetThemeBasedBidRecommendationForAdGroup_v1` | `POST /sp/targets/bid/recommendations` | `spthemebasedbidrecommendation` | 3, 4, 5 |
+| `getTargetableCategories` | `GET /sp/targets/categories` | `spproducttargetingresponse` | 3, 4, 5 |
+| `getCategoryRecommendationsForASINs` | `POST /sp/targets/categories/recommendations` | `spproducttargetingresponse` | 3, 4, 5 |
+| `getRefinementsForCategory` | `GET /sp/targets/category/{categoryId}/refinements` | `spproducttargetingresponse` | 3, 4 |
+| `CreateOptimizationRules`, `UpdateOptimizationRules`, `SearchOptimizationRules` | `/sp/rules/optimization*` | `spoptimizationrules` | 1, 2 |
+| `CreateTargetPromotionGroups`, `ListTargetPromotionGroups` | `/sp/targetPromotionGroups[/list]` | `sptargetpromotiongroup` | 1, 2 |
+| `CreateTargetPromotionGroupTargets`, `ListTargetPromotionGroupTargets` | `/sp/targetPromotionGroups/targets[/list]` | `sptargetpromotiongrouptarget` | 1, 2 |
+
+For all of these, `MediaTypeRegistry.resolve(method, url)` returns an `accepts` list whose first vendored entry is whichever version the spec lists first. Today that is silently the lowest version, which is why `sp_getRankedKeywordRecommendation` 500s on Amazon's current shape. The TPG operations 200 today only because v1 and v2 happen to remain compatible — the same shape problem would bite the moment Amazon makes v2 the required version for a given request body.
+
+## Goals
+
+1. **Single source of truth for Accept resolution.** Replace the two blocks in `_inject_headers` with one call into a pure resolver.
+2. **Prefer highest `vN+json` from spec-declared accepts** when multiple versions are present. Highest-major wins; on ties, highest-minor wins; on full ties, preserve spec order.
+3. **Preserve PR #68's wire contract:**
+   - Caller-pinned vendored Accept (e.g. tool explicitly sets `application/vnd.sptargetpromotiongroup.v2+json`) is never overridden.
+   - Missing Accept, `*/*`, or non-vendored Accept gets upgraded to the highest spec-declared vendored type when one exists.
+4. **Make the policy testable in isolation** as a pure function — no `httpx.AsyncClient` mock plumbing required for unit tests.
+5. **Fold the download/report Accept heuristic into the same resolver** so there is one decision point. The download list is layered as a tie-breaker preference, not a separate writeback.
+
+## Non-goals
+
+- No change to `MediaTypeRegistry`'s storage shape (`_req_entries`, `_resp_entries` stay as lists of dicts).
+- No change to `build_media_maps_from_spec` extraction logic — the resolver consumes what the registry already exposes.
+- No change to download endpoint semantics — `resolve_download_accept_headers` keeps its current contract.
+- No change to header-resolver (`HeaderNameResolver`) — it doesn't touch Accept.
+- No `*.media.json` sidecar work (that's a separate dead-data issue PR #68's author flagged; track it elsewhere).
+
+## Proposed shape
+
+### New module: `utils/media/accept_resolver.py`
+
+A pure-function resolver that owns the policy. No I/O, no httpx coupling.
+
+```python
+from typing import Iterable, Optional, Tuple
+import re
+
+# application/vnd.<base>.v<major>[.<minor>]+json
+_VENDORED_RE = re.compile(
+    r"^application/vnd\.([A-Za-z0-9]+)\.v(\d+)(?:\.(\d+))?\+json$"
+)
+
+
+def parse_vendored(ct: str) -> Optional[Tuple[str, int, int]]:
+    """Return (base, major, minor) for application/vnd.<base>.v<N>[.<M>]+json,
+    or None for any other content type. Minor defaults to 0."""
+    m = _VENDORED_RE.match(ct or "")
+    if not m:
+        return None
+    return m.group(1).lower(), int(m.group(2)), int(m.group(3) or 0)
+
+
+def pick_highest_vendored(accepts: Iterable[str]) -> Optional[str]:
+    """Pick the highest vN[.M]+json from an ordered list. Ties keep spec order."""
+    best: Optional[Tuple[Tuple[int, int], int, str]] = None
+    for idx, ct in enumerate(accepts or ()):
+        parsed = parse_vendored(ct)
+        if not parsed:
+            continue
+        _, major, minor = parsed
+        # idx negated so earlier entries win on full version ties
+        key = ((major, minor), -idx)
+        if best is None or key > best[:2]:
+            best = (key[0], key[1], ct)
+    return best[2] if best else None
+
+
+def resolve_accept(
+    *,
+    spec_accepts: Optional[list[str]],
+    existing: Optional[str],
+    download_overrides: Optional[list[str]] = None,
+) -> Optional[str]:
+    """Decide the Accept header value to set on a request.
+
+    Returns the new value, or None to leave the request's Accept unchanged.
+
+    Policy (in order):
+      1. Caller-pinned vendored Accept (existing starts with "application/vnd.")
+         is preserved — return None.
+      2. If spec_accepts contains a vendored type, pick the highest vN+json.
+         If existing is missing/"*/*"/non-vendored, return that.
+      3. If spec_accepts has no vendored type but has any value, fall back to
+         the first listed when existing is missing/"*/*".
+      4. If download_overrides intersects spec_accepts, prefer that intersection.
+         If no spec_accepts but existing is missing/"*/*", use overrides[0].
+      5. Otherwise return None (leave existing alone).
+    """
+    existing_norm = (existing or "").strip()
+    is_vendored_existing = existing_norm.startswith("application/vnd.")
+
+    # Rule 1: caller-pinned vendored wins
+    if is_vendored_existing:
+        return None
+
+    # Rule 4 (intersection branch): download overrides + spec accepts
+    if download_overrides and spec_accepts:
+        for ct in download_overrides:
+            if ct in spec_accepts:
+                if existing_norm in ("", "*/*") or not _is_vendored(existing_norm):
+                    return ct
+
+    # Rule 2: highest vendored from spec
+    highest = pick_highest_vendored(spec_accepts or ())
+    if highest and (
+        existing_norm == "" or existing_norm == "*/*" or not _is_vendored(existing_norm)
+    ):
+        return highest
+
+    # Rule 3: spec accepts present but no vendored entry
+    if spec_accepts and (existing_norm == "" or existing_norm == "*/*"):
+        return spec_accepts[0]
+
+    # Rule 4 (download-only branch): no spec accepts to intersect against
+    if download_overrides and (existing_norm == "" or existing_norm == "*/*"):
+        return download_overrides[0]
+
+    return None
+
+
+def _is_vendored(ct: str) -> bool:
+    return ct.startswith("application/vnd.")
+```
+
+### `_inject_headers` collapses to one call
+
+```python
+# 1) MEDIA NEGOTIATION
+if self.media_registry:
+    content_type, accepts = self.media_registry.resolve(method, url)
+    if content_type and method.lower() != "get":
+        request.headers["Content-Type"] = content_type
+else:
+    accepts = None
+
+try:
+    overrides = resolve_download_accept_headers(method, url) or None
+except Exception as e:
+    logger.debug("Download Accept resolver skipped: %s", e)
+    overrides = None
+
+new_accept = resolve_accept(
+    spec_accepts=accepts,
+    existing=request.headers.get("Accept"),
+    download_overrides=overrides,
+)
+if new_accept:
+    request.headers["Accept"] = new_accept
+```
+
+That replaces lines 520-577 of the post-PR-68 `_inject_headers` (~58 lines) with ~16 lines and zero policy logic.
+
+## Version-selection algorithm details
+
+`parse_vendored` and `pick_highest_vendored` need explicit edge-case behavior locked by tests:
+
+- `application/vnd.spkeywordsrecommendation.v3+json` → `(spkeywordsrecommendation, 3, 0)`
+- `application/vnd.measurementresult.v1.2+csv` → **not vendored JSON, returns None** (download resolver still handles CSV via `download_overrides`)
+- `application/vnd.insightsbrandmetrics.v1.1+json` → `(insightsbrandmetrics, 1, 1)`
+- Among `[v3+json, v4+json, v5+json]` → picks `v5+json`
+- Among `[v1.0+json, v1.2+json, v1.1+json]` → picks `v1.2+json`
+- Among `[v3+json, v3+json]` (duplicate listing) → picks first (spec order tie-break)
+- Mixed bases (e.g. an operation that lists `spfoo.v1+json` and `spbar.v2+json` in one operation) → picks highest version regardless of base. **This is rare and worth a contract test;** if real specs do this we need to defer to spec ordering instead.
+
+The tie-break choice (earlier index wins on full-tie) is intentional: when Amazon decides v3 is the right default and lists it first, we honor that.
+
+## Test matrix
+
+### Unit tests for `accept_resolver.py` (new file `tests/unit/test_accept_resolver.py`)
+
+Pure-function tests, no httpx mocking. Each row is one assertion:
+
+| Case | spec_accepts | existing | download_overrides | expected |
+|---|---|---|---|---|
+| Empty inputs | None | None | None | None |
+| Missing Accept, single vendored | `["application/vnd.spCampaign.v3+json"]` | None | None | `vnd.spCampaign.v3+json` |
+| `*/*` Accept, single vendored | `["application/vnd.spCampaign.v3+json"]` | `"*/*"` | None | `vnd.spCampaign.v3+json` |
+| Non-vendored Accept, vendored available | `["application/vnd.spCampaign.v3+json"]` | `"application/json"` | None | `vnd.spCampaign.v3+json` |
+| Caller-pinned vendored | `["application/vnd.tpg.v1+json", "application/vnd.tpg.v2+json"]` | `"application/vnd.tpg.v2+json"` | None | None |
+| Caller-pinned vendored even when "wrong" | `["application/vnd.tpg.v2+json"]` | `"application/vnd.tpg.v1+json"` | None | None |
+| Multi-version: highest wins | `[v3, v4, v5]` | `"*/*"` | None | `v5+json` |
+| Multi-version: highest wins despite spec order | `[v5, v3, v4]` | `"*/*"` | None | `v5+json` |
+| Major.minor: highest minor wins | `[v1.0, v1.2, v1.1]` | `"*/*"` | None | `v1.2+json` |
+| Major beats minor | `[v1.99, v2.0]` | `"*/*"` | None | `v2.0+json` |
+| Spec order tie-break on full version equality | `[v3+json, v3+json]` | `"*/*"` | None | first `v3+json` (id-stable) |
+| No vendored in spec accepts, missing existing | `["application/json"]` | None | None | `"application/json"` |
+| Download override intersects spec | `["application/vnd.adsexport.v1+json", "application/json"]` | None | `["application/vnd.adsexport.v1+json"]` | `vnd.adsexport.v1+json` |
+| Download override doesn't intersect | `["application/vnd.spCampaign.v3+json"]` | `"*/*"` | `["text/csv"]` | `vnd.spCampaign.v3+json` (rule 2 wins) |
+| Download override only, no spec | None | `"*/*"` | `["text/csv"]` | `"text/csv"` |
+| Caller-pinned vendored + download override available | `["application/vnd.x.v1+json"]` | `"application/vnd.x.v1+json"` | `["application/json"]` | None (rule 1 absolute) |
+| Empty string Accept (whitespace) treated as missing | `["application/vnd.x.v1+json"]` | `"   "` | None | `vnd.x.v1+json` |
+| `*/*` with whitespace | `["application/vnd.x.v1+json"]` | `" */* "` | None | `vnd.x.v1+json` |
+| Non-JSON vendored ignored by `pick_highest_vendored` | `["application/vnd.measurementresult.v1.2+csv"]` | `"*/*"` | None | None or first-listed (decide and lock) |
+
+### PR #68 regression tests (preserved verbatim, must continue to pass)
+
+- `tests/unit/test_client_accept_resolver.py::test_httpx_default_accept_is_overridden_with_vendored_type`
+- `tests/unit/test_client_accept_resolver.py::test_explicit_vendored_accept_is_preserved`
+
+These exercise the full `AuthenticatedClient.send` path with a mocked `MediaTypeRegistry`. They lock the wire contract PR #68 shipped. The refactor must not change their assertions. If we need to update the mocks because the resolver moved, that's fine — assertions stay identical.
+
+### New integration test against real spec data
+
+`tests/unit/test_accept_resolver_against_spec.py` — loads `dist/openapi/resources/SponsoredProducts.json`, builds a real `MediaTypeRegistry`, and asserts:
+
+- `getRankedKeywordRecommendation` resolves to `application/vnd.spkeywordsrecommendation.v5+json` (the headline fix)
+- `GetThemeBasedBidRecommendationForAdGroup_v1` resolves to `v5+json`
+- `getTargetableCategories` resolves to `v5+json`
+- `getCategoryRecommendationsForASINs` resolves to `v5+json`
+- `getRefinementsForCategory` resolves to `v4+json`
+- `CreateTargetPromotionGroups` resolves to `v2+json` (was v1 pre-refactor)
+- All SP v3 entity CRUD operations resolve to `v3+json` (PR #68's contract — only one version declared, so highest is unchanged)
+
+This test catches future regressions where:
+- A new spec introduces a v6 and we need to confirm we pick it up automatically.
+- Someone "fixes" the version logic in a way that breaks the spec contract.
+- The spec extraction in `build_media_maps_from_spec` changes shape.
+
+### Live-wire smoke (manual, not in CI)
+
+Document a verification recipe in the PR body:
+
+```bash
+# Force resolved-version Accept on the headline endpoint
+uv run python -c "
+import asyncio
+from amazon_ads_mcp.utils.media import MediaTypeRegistry
+import json
+
+reg = MediaTypeRegistry()
+with open('dist/openapi/resources/SponsoredProducts.json') as f:
+    reg.add_from_spec(json.load(f))
+
+ct, accepts = reg.resolve('POST', 'https://advertising-api.amazon.com/sp/targets/keywords/recommendations')
+print('content-type:', ct)
+print('accepts:', accepts)
+"
+# Expected: accepts contains v3, v4, v5; resolve_accept picks v5
+```
+
+## Regression protection
+
+Three layers:
+
+1. **Pure-function unit tests** (table above) — fast, catches policy regressions in milliseconds.
+2. **Spec-contract test** — catches drift between spec and resolver assumptions. Runs against committed `dist/openapi/resources/SponsoredProducts.json`; will need updating when the spec is regenerated.
+3. **PR #68 wire contract tests** kept verbatim — catches any change to the `AuthenticatedClient` integration.
+
+CI status: all three layers run under `uv run pytest` (default `-v` from pyproject.toml). The spec-contract test is fast (~50ms to load the spec) and can stay unmarked. No new `slow` markers needed.
+
+## Rollout
+
+This is a pure refactor of internal behavior with one intentional contract change (highest-version preference for multi-version operations). No env var gating needed.
+
+1. Land the resolver module + unit tests in one commit.
+2. Land the `_inject_headers` collapse + spec-contract test + PR #68 regression tests in a second commit.
+3. Run full suite + linting.
+4. PR description: link to this roadmap doc, list the operations whose resolved Accept changes (the multi-version table above), and call out `getRankedKeywordRecommendation` as the headline regression fix.
+5. CHANGELOG entry under `Fixed`: "HTTP: prefer highest spec-declared `vN+json` for multi-version Amazon Ads operations (resolves pre-existing 500 on `sp_getRankedKeywordRecommendation` flagged in PR #68)."
+
+No version bump triggered by this alone (it's a `fix:` per Conventional Commits, patch bump only when merged).
+
+## Open questions to resolve during implementation
+
+1. **Mixed-base accepts in one operation.** Does any current SponsoredProducts operation list two different `base` names in one accepts list? If yes, "highest version regardless of base" may be wrong; we'd need to bucket by base. Verify by extending the spec scan above.
+2. **Non-JSON vendored types.** `application/vnd.measurementresult.v1.2+csv` is a real declared type. Should `pick_highest_vendored` consider non-JSON, or strictly JSON? Current proposal: JSON-only. The CSV case stays in `download_overrides`. Lock the behavior in the test row marked "decide and lock".
+3. **`Content-Type` parity.** PR #68 only patched Accept. Do request bodies on multi-version operations also need a "highest vN+json" Content-Type? Current `MediaTypeRegistry.resolve` returns `req_map.get(...)` which is a single string, not a list, so the same picker doesn't apply directly. Worth a separate scan to confirm Content-Type is single-valued in every multi-version op; if not, expand the resolver.
+4. **`HeaderNameResolver` interaction.** Confirmed not touched by Accept. No work needed.
+
+## Out of scope (track separately)
+
+- Dead `*.media.json` sidecar files in `dist/openapi/resources/` (PR #68 author flagged the shape mismatch with `MediaTypeRegistry.add_from_sidecar`). Open a separate cleanup issue.
+- Cross-server error envelope contract work (separate roadmap, separate branch).
+- Code Mode-side surfacing of the new resolver decisions (none needed; resolver runs at the transport layer below code mode).

--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -34,6 +34,7 @@ from ..utils.export_content_type_resolver import (
 )
 from ..utils.header_resolver import HeaderNameResolver
 from ..utils.media import MediaTypeRegistry
+from ..utils.media.accept_resolver import resolve_accept
 from ..utils.region_config import RegionConfig
 
 logger = logging.getLogger(__name__)
@@ -519,59 +520,31 @@ class AuthenticatedClient(httpx.AsyncClient):
         path = urlparse(url).path
 
         # 1) MEDIA NEGOTIATION
+        # Content-Type stays inline (single-valued from the registry).
+        # Accept is delegated to the unified resolver — see
+        # ``utils/media/accept_resolver.py`` for the locked policy. The two
+        # parallel Accept blocks that lived here pre-refactor (PR #68 era)
+        # are now collapsed into one resolve_accept() call so the policy
+        # has one home and one test surface.
+        accepts = None
         if self.media_registry:
             content_type, accepts = self.media_registry.resolve(method, url)
             if content_type and method.lower() != "get":
                 request.headers["Content-Type"] = content_type
-            if accepts:
-                preferred = next(
-                    (a for a in accepts if a.startswith("application/vnd.")),
-                    accepts[0],
-                )
-                existing = (request.headers.get("Accept") or "").strip()
-                # Amazon's v3 gateway strictly enforces per-operation media
-                # types. Override generic fallbacks (missing, "*/*",
-                # non-vendored) with the spec-declared vendored type when
-                # one exists. httpx defaults Accept to "*/*", which the
-                # previous "not in headers" guard treated as caller-set
-                # and skipped — causing 415s on SP v3 + TPG v1 endpoints.
-                # Respect callers who explicitly pass a vendored Accept
-                # (e.g. pinning TargetPromotionGroups v2).
-                should_override = (
-                    not existing
-                    or existing == "*/*"
-                    or (
-                        preferred.startswith("application/vnd.")
-                        and not existing.startswith("application/vnd.")
-                    )
-                )
-                if should_override:
-                    request.headers["Accept"] = preferred
 
-        # Heuristic Accept override for known download/report endpoints
-        if (
-            "Accept" not in request.headers
-            or (request.headers.get("Accept") or "").strip() == "*/*"
-        ):
-            try:
-                overrides = resolve_download_accept_headers(method, url)
-                if overrides:
-                    if self.media_registry:
-                        # Intersect with available accepts if we have them
-                        _, accepts = self.media_registry.resolve(method, url)
-                        if accepts:
-                            for ct in overrides:
-                                if ct in accepts:
-                                    request.headers["Accept"] = ct
-                                    break
-                            else:
-                                request.headers["Accept"] = overrides[0]
-                        else:
-                            request.headers["Accept"] = overrides[0]
-                    else:
-                        request.headers["Accept"] = overrides[0]
-            except Exception as e:
-                logger.debug("Accept override skipped: %s", e)
+        try:
+            download_overrides = resolve_download_accept_headers(method, url) or None
+        except Exception as e:
+            logger.debug("Download Accept resolver skipped: %s", e)
+            download_overrides = None
+
+        new_accept = resolve_accept(
+            spec_accepts=accepts,
+            existing=request.headers.get("Accept"),
+            download_overrides=download_overrides,
+        )
+        if new_accept:
+            request.headers["Accept"] = new_accept
 
         # 2) STRIP POLLUTED HEADERS
         removed = []

--- a/src/amazon_ads_mcp/utils/media/accept_resolver.py
+++ b/src/amazon_ads_mcp/utils/media/accept_resolver.py
@@ -1,0 +1,192 @@
+"""Pure-function Accept-header resolver.
+
+Owns the policy for choosing an HTTP ``Accept`` value at request time. Decoupled
+from ``httpx`` and from :class:`MediaTypeRegistry` so the policy can be unit
+tested in isolation. ``AuthenticatedClient._inject_headers`` is the only
+production caller; tests inject ``spec_accepts`` directly.
+
+Design discipline (see ``docs/roadmap/unified-accept-resolver.md``):
+
+* Spec-driven, not hand-curated. The picker prefers the highest spec-declared
+  ``vN[.M]+json``. There is no per-operation override mechanism — tools that
+  need a specific version pin Accept at the call site (preserved by the
+  caller-pinned rule below).
+* The CSV / non-JSON variants live behind ``download_overrides`` and are
+  treated as opaque first-listed by this resolver — non-JSON semantics are
+  the download path's concern.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional, Tuple
+
+# application/vnd.<base>.v<major>[.<minor>]+json
+#
+# Base allows alphanumerics, dots, hyphens, underscores. Real specs use
+# compound bases such as ``spproductrecommendationresponse.asins`` and
+# ``SponsoredBrands.SponsoredBrandsMigrationApi``; narrower regexes drop
+# valid types silently and produce 415 / 500 against Amazon.
+_VENDORED_JSON_RE = re.compile(
+    r"^application/vnd\.([A-Za-z0-9._-]+)\.v(\d+)(?:\.(\d+))?\+json$"
+)
+
+
+def parse_vendored_json(ct: Optional[str]) -> Optional[Tuple[str, int, int]]:
+    """Parse a vendored JSON content type into ``(base, major, minor)``.
+
+    Returns ``None`` for any content type that is not
+    ``application/vnd.<base>.v<N>[.<M>]+json``. Notably ``None`` for
+    ``text/vnd.*+csv`` variants and for bare ``application/vnd.<base>.v<N>``
+    types with no ``+json`` suffix — those are out of scope for the picker
+    and surface via the first-listed fallback. ``minor`` defaults to 0.
+    Base is lowercased for stable comparison.
+    """
+    if not ct:
+        return None
+    m = _VENDORED_JSON_RE.match(ct)
+    if not m:
+        return None
+    return m.group(1).lower(), int(m.group(2)), int(m.group(3) or 0)
+
+
+def pick_highest_vendored_json(accepts: Optional[Iterable[str]]) -> Optional[str]:
+    """Pick the highest ``vN[.M]+json`` from a list of content types.
+
+    Returns ``None`` when:
+
+    * the input is empty or contains no vendored JSON types, or
+    * the input contains multiple distinct *bases* (e.g. an operation
+      declaring both ``spproductrecommendationresponse.asins`` and
+      ``…themes``). The picker abstains because version comparison cannot
+      decide between two semantic shapes; the caller is expected to fall
+      back to first-listed.
+
+    When a single base is present, returns the original content-type string
+    of the highest ``(major, minor)``.
+    """
+    if not accepts:
+        return None
+    parsed: List[Tuple[Tuple[str, int, int], str]] = []
+    for ct in accepts:
+        p = parse_vendored_json(ct)
+        if p is not None:
+            parsed.append((p, ct))
+    if not parsed:
+        return None
+    bases = {p[0] for (p, _) in parsed}
+    if len(bases) > 1:
+        return None  # mixed bases — abstain, let caller fall back
+    best = max(parsed, key=lambda item: (item[0][1], item[0][2]))
+    return best[1]
+
+
+def _is_vendored(ct: str) -> bool:
+    return ct.startswith("application/vnd.")
+
+
+def resolve_accept(
+    *,
+    spec_accepts: Optional[List[str]],
+    existing: Optional[str],
+    download_overrides: Optional[List[str]] = None,
+) -> Optional[str]:
+    """Decide the ``Accept`` header value to set on an outbound request.
+
+    Returns the new ``Accept`` value, or ``None`` to leave the request's
+    ``Accept`` unchanged.
+
+    Policy (executed in this order — code below mirrors the docstring exactly):
+
+    1. **Caller-pinned vendored Accept is preserved unconditionally.**
+       If ``existing`` starts with ``application/vnd.``, return ``None``
+       (do not modify). Tools that pin a specific version know what they need.
+    2. **Vendored intersection of download_overrides and spec_accepts.**
+       If any *vendored* value (``application/vnd.*`` or ``text/vnd.*``)
+       appears in both ``download_overrides`` and ``spec_accepts`` AND
+       ``existing`` is missing / ``"*/*"`` / non-vendored, return that
+       overlapping value. Non-vendored intersections (e.g. both sides
+       agreeing on ``application/json``) do NOT count — those are generic
+       fallbacks, not specific download contracts.
+    3. **Highest single-base vendored JSON from spec.**
+       If ``spec_accepts`` contains vendored JSON of a single base, pick the
+       highest ``vN[.M]+json``. Override ``existing`` only when missing /
+       ``"*/*"`` / non-vendored.
+    4. **First vendored from spec (any subtype).**
+       If ``spec_accepts`` has any ``application/vnd.*`` value but the
+       version picker abstained (mixed bases, non-version vendored types
+       like ``application/vnd.openxmlformats-…sheet``, etc.), return the
+       first vendored entry. Preserves "vendored beats generic" intent
+       even when version selection isn't applicable.
+    5. **First-listed spec value.**
+       When spec has values but nothing vendored, return the first-listed
+       only if ``existing`` is missing / ``"*/*"``. Don't touch a caller-set
+       non-vendored value.
+    6. **Download-only fallback.**
+       If only ``download_overrides`` exists (no ``spec_accepts``), return
+       ``download_overrides[0]`` when ``existing`` is missing / ``"*/*"``.
+    7. **Otherwise return None** (leave existing unchanged).
+    """
+    existing_norm = (existing or "").strip()
+    is_vendored_existing = existing_norm.startswith("application/vnd.")
+
+    # Rule 1: caller-pinned vendored wins
+    if is_vendored_existing:
+        return None
+
+    is_generic_existing = existing_norm in ("", "*/*")
+    is_overrideable = is_generic_existing or not _is_vendored(existing_norm)
+
+    # Rule 2: vendored ∩ of download_overrides and spec_accepts
+    if download_overrides and spec_accepts and is_overrideable:
+        spec_set = set(spec_accepts)
+        for ct in download_overrides:
+            if ct in spec_set and (
+                ct.startswith("application/vnd.") or ct.startswith("text/vnd.")
+            ):
+                return ct
+
+    # Rule 3: highest vendored JSON from spec (single base)
+    highest = pick_highest_vendored_json(spec_accepts)
+    if highest and is_overrideable:
+        return highest
+
+    # Distinguish WHY the picker abstained: if any +json vendored type exists,
+    # abstention means mixed bases (we can't decide between asins/themes-style
+    # shapes by version comparison). When that's the case, do NOT silently
+    # pick a vendored value via rule 4 — fall to first-listed so application/json
+    # surfaces the ambiguity to the caller. Rule 4 is reserved for the case
+    # where there's no vendored JSON to compare in the first place
+    # (e.g. xlsx mime, csv, brand-specific binaries).
+    has_vendored_json = bool(spec_accepts) and any(
+        parse_vendored_json(ct) is not None for ct in spec_accepts
+    )
+
+    # Rule 4: first vendored from spec (any subtype) when picker had nothing
+    # to compare. Preserves "vendored over generic" intent for non-version
+    # vendored types like application/vnd.openxmlformats-…sheet.
+    if spec_accepts and is_overrideable and not has_vendored_json:
+        first_vendored = next(
+            (ct for ct in spec_accepts if _is_vendored(ct)),
+            None,
+        )
+        if first_vendored:
+            return first_vendored
+
+    # Rule 5: spec has values, fall back to first-listed
+    if spec_accepts and is_generic_existing:
+        return spec_accepts[0]
+
+    # Rule 6: download-only (no spec accepts)
+    if download_overrides and is_generic_existing:
+        return download_overrides[0]
+
+    # Rule 7: leave alone
+    return None
+
+
+__all__ = [
+    "parse_vendored_json",
+    "pick_highest_vendored_json",
+    "resolve_accept",
+]

--- a/tests/unit/test_accept_resolver.py
+++ b/tests/unit/test_accept_resolver.py
@@ -1,0 +1,535 @@
+"""Pure-function tests for the unified Accept-header resolver.
+
+This module exercises ``parse_vendored_json``, ``pick_highest_vendored_json``
+and ``resolve_accept`` directly. By contract (see
+``docs/roadmap/unified-accept-resolver.md`` — "Source-agnosticism guarantee"),
+none of these tests instantiates ``MediaTypeRegistry``: ``spec_accepts`` is
+always passed as a list literal so the resolver's policy can never accidentally
+couple to a particular data source. The integration test in
+``test_accept_resolver_against_spec.py`` is the only place where the resolver
+runs against a real registry.
+"""
+
+import pytest
+
+from amazon_ads_mcp.utils.media.accept_resolver import (
+    parse_vendored_json,
+    pick_highest_vendored_json,
+    resolve_accept,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_vendored_json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ct,expected",
+    [
+        # Single-segment base
+        (
+            "application/vnd.spkeywordsrecommendation.v3+json",
+            ("spkeywordsrecommendation", 3, 0),
+        ),
+        # Major.minor
+        (
+            "application/vnd.insightsbrandmetrics.v1.1+json",
+            ("insightsbrandmetrics", 1, 1),
+        ),
+        # Dotted base (real type from SP spec)
+        (
+            "application/vnd.spproductrecommendationresponse.asins.v3+json",
+            ("spproductrecommendationresponse.asins", 3, 0),
+        ),
+        # Compound base with mixed case (real type)
+        (
+            "application/vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json",
+            ("sponsoredbrands.sponsoredbrandsmigrationapi", 4, 0),
+        ),
+        # Hyphen in base — locked by widened character class
+        (
+            "application/vnd.some-base.v2+json",
+            ("some-base", 2, 0),
+        ),
+        # Underscore in base — locked by widened character class
+        (
+            "application/vnd.some_base.v2+json",
+            ("some_base", 2, 0),
+        ),
+        # Non-JSON CSV — opaque to picker, parser returns None
+        ("text/vnd.measurementresult.v1.2+csv", None),
+        # Bare version, no +json — real type from spec, parser intentionally rejects
+        ("application/vnd.GlobalRegistrationService.TermsTokenResource.v1", None),
+        # Plain JSON — not vendored
+        ("application/json", None),
+        # Not even close
+        ("text/csv", None),
+        # Empty / None inputs
+        ("", None),
+    ],
+)
+def test_parse_vendored_json_table(ct, expected):
+    assert parse_vendored_json(ct) == expected
+
+
+def test_parse_vendored_json_handles_none_input():
+    """Defensive: callers may pass None when accepts list contains gaps."""
+    assert parse_vendored_json(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# pick_highest_vendored_json
+# ---------------------------------------------------------------------------
+
+
+def test_picker_returns_none_for_empty_list():
+    assert pick_highest_vendored_json([]) is None
+    assert pick_highest_vendored_json(None) is None  # type: ignore[arg-type]
+
+
+def test_picker_returns_none_when_no_vendored_json_present():
+    assert pick_highest_vendored_json(["application/json", "text/csv"]) is None
+
+
+def test_picker_single_base_picks_highest_major():
+    accepts = [
+        "application/vnd.spkeywordsrecommendation.v3+json",
+        "application/vnd.spkeywordsrecommendation.v4+json",
+        "application/vnd.spkeywordsrecommendation.v5+json",
+    ]
+    assert (
+        pick_highest_vendored_json(accepts)
+        == "application/vnd.spkeywordsrecommendation.v5+json"
+    )
+
+
+def test_picker_single_base_is_order_independent():
+    accepts = [
+        "application/vnd.x.v5+json",
+        "application/vnd.x.v3+json",
+        "application/vnd.x.v4+json",
+    ]
+    assert pick_highest_vendored_json(accepts) == "application/vnd.x.v5+json"
+
+
+def test_picker_major_minor_highest_minor_wins():
+    accepts = [
+        "application/vnd.x.v1.0+json",
+        "application/vnd.x.v1.2+json",
+        "application/vnd.x.v1.1+json",
+    ]
+    assert pick_highest_vendored_json(accepts) == "application/vnd.x.v1.2+json"
+
+
+def test_picker_major_beats_minor():
+    accepts = [
+        "application/vnd.x.v1.99+json",
+        "application/vnd.x.v2.0+json",
+    ]
+    assert pick_highest_vendored_json(accepts) == "application/vnd.x.v2.0+json"
+
+
+def test_picker_abstains_on_mixed_bases():
+    """Real case: SP declares both spproductrecommendationresponse.asins and
+    .themes on the same operation. Picker cannot decide between two semantic
+    shapes by version comparison alone — returns None so resolve_accept rule 4
+    falls back to first-listed.
+    """
+    accepts = [
+        "application/vnd.spproductrecommendationresponse.asins.v3+json",
+        "application/vnd.spproductrecommendationresponse.themes.v3+json",
+    ]
+    assert pick_highest_vendored_json(accepts) is None
+
+
+def test_picker_abstains_on_mixed_bases_even_with_version_difference():
+    accepts = [
+        "application/vnd.foo.v3+json",
+        "application/vnd.bar.v5+json",
+    ]
+    assert pick_highest_vendored_json(accepts) is None
+
+
+def test_picker_ignores_non_json_when_mixed_with_json():
+    """JSON-only contract: a CSV variant alongside a JSON variant doesn't
+    confuse the picker — the CSV is invisible to it."""
+    accepts = [
+        "application/vnd.x.v1+json",
+        "text/vnd.x.v1.2+csv",
+    ]
+    assert pick_highest_vendored_json(accepts) == "application/vnd.x.v1+json"
+
+
+# ---------------------------------------------------------------------------
+# resolve_accept — the locked policy table from the roadmap doc
+# ---------------------------------------------------------------------------
+
+
+def test_empty_inputs_return_none():
+    assert resolve_accept(spec_accepts=None, existing=None) is None
+
+
+def test_missing_accept_with_single_vendored_returns_vendored():
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.spCampaign.v3+json"],
+            existing=None,
+        )
+        == "application/vnd.spCampaign.v3+json"
+    )
+
+
+def test_star_accept_with_single_vendored_returns_vendored():
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.spCampaign.v3+json"],
+            existing="*/*",
+        )
+        == "application/vnd.spCampaign.v3+json"
+    )
+
+
+def test_non_vendored_existing_with_vendored_available_upgrades():
+    """The most controversial rule from PR #68's should_override boolean,
+    now explicit and tested."""
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.spCampaign.v3+json"],
+            existing="application/json",
+        )
+        == "application/vnd.spCampaign.v3+json"
+    )
+
+
+def test_caller_pinned_vendored_is_preserved():
+    """Rule 1 absolute. Caller picked v2 explicitly; resolver doesn't second-guess."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.tpg.v1+json",
+                "application/vnd.tpg.v2+json",
+            ],
+            existing="application/vnd.tpg.v2+json",
+        )
+        is None
+    )
+
+
+def test_caller_pinned_vendored_preserved_even_if_lower_than_spec():
+    """Rule 1 holds even when caller-pinned version is OLDER than spec offers."""
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.tpg.v2+json"],
+            existing="application/vnd.tpg.v1+json",
+        )
+        is None
+    )
+
+
+def test_multi_version_highest_wins():
+    """The headline regression fix this PR exists for."""
+    accepts = [
+        "application/vnd.spkeywordsrecommendation.v3+json",
+        "application/vnd.spkeywordsrecommendation.v4+json",
+        "application/vnd.spkeywordsrecommendation.v5+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.spkeywordsrecommendation.v5+json"
+    )
+
+
+def test_multi_version_highest_wins_regardless_of_input_order():
+    accepts = [
+        "application/vnd.x.v5+json",
+        "application/vnd.x.v3+json",
+        "application/vnd.x.v4+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.x.v5+json"
+    )
+
+
+def test_major_minor_highest_minor_wins():
+    accepts = [
+        "application/vnd.x.v1.0+json",
+        "application/vnd.x.v1.2+json",
+        "application/vnd.x.v1.1+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.x.v1.2+json"
+    )
+
+
+def test_major_beats_minor():
+    accepts = [
+        "application/vnd.x.v1.99+json",
+        "application/vnd.x.v2.0+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.x.v2.0+json"
+    )
+
+
+def test_dotted_base_resolves_correctly():
+    """Real spec type — verifies widened regex flows through the resolver."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.spproductrecommendationresponse.asins.v3+json"
+            ],
+            existing=None,
+        )
+        == "application/vnd.spproductrecommendationresponse.asins.v3+json"
+    )
+
+
+def test_compound_base_resolves_correctly():
+    """Compound base from real SponsoredBrands spec."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json"
+            ],
+            existing=None,
+        )
+        == "application/vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json"
+    )
+
+
+def test_mixed_bases_falls_back_to_first_listed():
+    """Picker abstains; rule 4 returns first-listed (after registry's lexical sort)."""
+    accepts = [
+        "application/vnd.x.asins.v3+json",
+        "application/vnd.x.themes.v3+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.x.asins.v3+json"
+    )
+
+
+def test_mixed_bases_with_version_difference_falls_back_to_first_listed():
+    """Picker abstains because two distinct bases — rule 4 gets first-listed."""
+    accepts = [
+        "application/vnd.bar.v5+json",
+        "application/vnd.foo.v3+json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.bar.v5+json"
+    )
+
+
+def test_no_vendored_spec_accepts_with_missing_existing():
+    """Rule 4 fallback when spec has values but no vendored JSON."""
+    assert (
+        resolve_accept(spec_accepts=["application/json"], existing=None)
+        == "application/json"
+    )
+
+
+def test_download_override_intersects_spec_wins_over_highest():
+    """Rule 2: the download contract is more specific than the spec's
+    'highest' heuristic. Even though the picker would pick v1 here too,
+    rule 2 fires first and bypasses the picker."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.adsexport.v1+json",
+                "application/json",
+            ],
+            existing=None,
+            download_overrides=["application/vnd.adsexport.v1+json"],
+        )
+        == "application/vnd.adsexport.v1+json"
+    )
+
+
+def test_download_override_does_not_intersect_spec_picker_wins():
+    """Rule 2 misses (no intersection); rule 3 picks highest vendored."""
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.spCampaign.v3+json"],
+            existing="*/*",
+            download_overrides=["text/csv"],
+        )
+        == "application/vnd.spCampaign.v3+json"
+    )
+
+
+def test_download_override_only_no_spec_returns_first():
+    """Rule 5: no spec data, take overrides[0]."""
+    assert (
+        resolve_accept(
+            spec_accepts=None,
+            existing="*/*",
+            download_overrides=["text/csv"],
+        )
+        == "text/csv"
+    )
+
+
+def test_caller_pinned_beats_download_override():
+    """Rule 1 is absolute — even download_overrides cannot displace
+    a caller-pinned vendored Accept."""
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.x.v1+json"],
+            existing="application/vnd.x.v1+json",
+            download_overrides=["application/json"],
+        )
+        is None
+    )
+
+
+def test_whitespace_only_existing_treated_as_missing():
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.x.v1+json"],
+            existing="   ",
+        )
+        == "application/vnd.x.v1+json"
+    )
+
+
+def test_padded_star_treated_as_star():
+    assert (
+        resolve_accept(
+            spec_accepts=["application/vnd.x.v1+json"],
+            existing=" */* ",
+        )
+        == "application/vnd.x.v1+json"
+    )
+
+
+def test_non_json_vendored_only_returns_first_listed():
+    """text/vnd.…+csv is opaque to the picker (not +json). Rule 4 fires:
+    spec has values, picker returned None, existing is generic → first-listed.
+    The resolver stays neutral on non-JSON semantics; the download path
+    handles CSV elsewhere."""
+    assert (
+        resolve_accept(
+            spec_accepts=["text/vnd.measurementresult.v1.2+csv"],
+            existing="*/*",
+        )
+        == "text/vnd.measurementresult.v1.2+csv"
+    )
+
+
+def test_non_vendored_existing_with_no_spec_accepts_unchanged():
+    """No spec data, no download data — leave whatever caller set alone."""
+    assert (
+        resolve_accept(
+            spec_accepts=None,
+            existing="application/json",
+        )
+        is None
+    )
+
+
+def test_non_vendored_existing_with_no_vendored_in_spec_unchanged():
+    """Caller set application/json, spec also only knows application/json.
+    Nothing to upgrade to → leave alone."""
+    assert (
+        resolve_accept(
+            spec_accepts=["application/json"],
+            existing="application/json",
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: non-version vendored types (e.g. xlsx mime) preserved over generic
+# ---------------------------------------------------------------------------
+
+
+def test_non_version_vendored_in_spec_beats_application_json():
+    """Real case from existing test_authenticated_client.test_media_type_negotiation:
+    spec advertises an xlsx-style vendored type alongside application/json.
+    Picker abstains (no +json suffix), but rule 4 returns the vendored value.
+    Without this rule, the registry's lexical sort would put application/json
+    first and rule 5 would return it instead — losing the vendored intent."""
+    accepts = [
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/json",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
+def test_non_version_vendored_wins_regardless_of_spec_order():
+    """Same as above but with json first (post-lexical-sort order)."""
+    accepts = [
+        "application/json",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ]
+    assert (
+        resolve_accept(spec_accepts=accepts, existing="*/*")
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 hardening: only VENDORED intersections count
+# ---------------------------------------------------------------------------
+
+
+def test_non_vendored_download_intersection_does_not_clobber_vendored_pick():
+    """The download resolver returns ['application/json'] as a default for
+    unrecognized download endpoints. If we treated that as authoritative
+    intersection, we'd downgrade a vendored spec accept to application/json.
+    Rule 2 only counts intersections on vendored values, so the default
+    fallback can't suppress rule 3/4."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "application/json",
+            ],
+            existing="*/*",
+            download_overrides=["application/json"],  # default fallback only
+        )
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+
+
+def test_vendored_download_intersection_still_wins_over_picker():
+    """The export endpoint case: download resolver knows the specific vendored
+    type the endpoint serves; that wins over highest-version selection."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "application/vnd.campaignsexport.v1+json",
+                "application/json",
+            ],
+            existing="*/*",
+            download_overrides=[
+                "application/vnd.campaignsexport.v1+json",
+                "application/json",
+            ],
+        )
+        == "application/vnd.campaignsexport.v1+json"
+    )
+
+
+def test_text_vendored_download_intersection_wins():
+    """text/vnd.* counts as vendored for rule 2 intersection (CSV exports)."""
+    assert (
+        resolve_accept(
+            spec_accepts=[
+                "text/vnd.measurementresult.v1.2+csv",
+                "application/json",
+            ],
+            existing="*/*",
+            download_overrides=["text/vnd.measurementresult.v1.2+csv"],
+        )
+        == "text/vnd.measurementresult.v1.2+csv"
+    )

--- a/tests/unit/test_accept_resolver_against_spec.py
+++ b/tests/unit/test_accept_resolver_against_spec.py
@@ -1,0 +1,301 @@
+"""Spec-contract integration test for the Accept resolver.
+
+Loads the shipped ``dist/openapi/resources/SponsoredProducts.json`` (the only
+runtime spec source per the commit policy — `.build/` and `openapi/resources/`
+are private) and exercises the resolver against a real :class:`MediaTypeRegistry`
+to assert each multi-version operation resolves to its expected version.
+
+These predictions catch:
+
+* "Highest declared version" picker regressions (the headline fix).
+* Future Amazon spec changes that introduce a v6 — the test should auto-update
+  expectations on regen, surfacing version moves loudly.
+* Spec-extraction changes in ``build_media_maps_from_spec`` (e.g. dropping
+  the lexical sort) that would break order-independent guarantees.
+* The moment Amazon ships a multi-base accepts list — the mixed-base guard
+  iterates every operation and asserts the resolver doesn't crash.
+
+This is the ONLY test allowed to instantiate ``MediaTypeRegistry`` for resolver
+purposes (per the source-agnosticism guarantee in the roadmap doc). Pure-function
+unit tests in ``test_accept_resolver.py`` inject ``spec_accepts`` directly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from amazon_ads_mcp.utils.media import MediaTypeRegistry
+from amazon_ads_mcp.utils.media.accept_resolver import (
+    pick_highest_vendored_json,
+    resolve_accept,
+)
+
+# Path policy: tests reference dist/openapi/resources/, never .build/ or
+# openapi/resources/. dist/ is the only OpenAPI asset tree that ships.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SP_SPEC_PATH = _REPO_ROOT / "dist" / "openapi" / "resources" / "SponsoredProducts.json"
+
+
+@pytest.fixture(scope="module")
+def sp_registry() -> MediaTypeRegistry:
+    """Load SponsoredProducts.json into a real MediaTypeRegistry.
+
+    Module-scoped to amortize the ~50ms spec parse across every test in the
+    file. The registry is treated as read-only.
+    """
+    if not _SP_SPEC_PATH.exists():
+        pytest.skip(
+            f"SponsoredProducts spec not found at {_SP_SPEC_PATH}; "
+            "build the dist/ tree before running this test."
+        )
+    with open(_SP_SPEC_PATH) as f:
+        spec = json.load(f)
+    reg = MediaTypeRegistry()
+    reg.add_from_spec(spec)
+    return reg
+
+
+@pytest.fixture(scope="module")
+def sp_spec() -> dict:
+    """Raw SponsoredProducts spec for tests that walk paths directly."""
+    if not _SP_SPEC_PATH.exists():
+        pytest.skip(f"SponsoredProducts spec not found at {_SP_SPEC_PATH}")
+    with open(_SP_SPEC_PATH) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Headline regression fixes — multi-version operations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,expected_accept",
+    [
+        # The headline fix: was v3 (500), should be v5
+        (
+            "POST",
+            "/sp/targets/keywords/recommendations",
+            "application/vnd.spkeywordsrecommendation.v5+json",
+        ),
+        # Theme-based bid recommendation — same shape, different op
+        (
+            "POST",
+            "/sp/targets/bid/recommendations",
+            "application/vnd.spthemebasedbidrecommendation.v5+json",
+        ),
+        # Targetable categories — GET, multi-version
+        (
+            "GET",
+            "/sp/targets/categories",
+            "application/vnd.spproducttargetingresponse.v5+json",
+        ),
+        # Category recommendations for ASINs — POST, multi-version
+        (
+            "POST",
+            "/sp/targets/categories/recommendations",
+            "application/vnd.spproducttargetingresponse.v5+json",
+        ),
+        # Refinements — only v3/v4 declared, picker returns v4
+        (
+            "GET",
+            "/sp/targets/category/{categoryId}/refinements",
+            "application/vnd.spproducttargetingresponse.v4+json",
+        ),
+        # Optimization rules — v1/v2, picker returns v2
+        (
+            "POST",
+            "/sp/rules/optimization",
+            "application/vnd.spoptimizationrules.v2+json",
+        ),
+        (
+            "PUT",
+            "/sp/rules/optimization",
+            "application/vnd.spoptimizationrules.v2+json",
+        ),
+        (
+            "POST",
+            "/sp/rules/optimization/search",
+            "application/vnd.spoptimizationrules.v2+json",
+        ),
+        # Target promotion groups — v1/v2, picker returns v2
+        (
+            "POST",
+            "/sp/targetPromotionGroups",
+            "application/vnd.sptargetpromotiongroup.v2+json",
+        ),
+        (
+            "POST",
+            "/sp/targetPromotionGroups/list",
+            "application/vnd.sptargetpromotiongroup.v2+json",
+        ),
+        (
+            "POST",
+            "/sp/targetPromotionGroups/targets",
+            "application/vnd.sptargetpromotiongrouptarget.v2+json",
+        ),
+        (
+            "POST",
+            "/sp/targetPromotionGroups/targets/list",
+            "application/vnd.sptargetpromotiongrouptarget.v2+json",
+        ),
+    ],
+)
+def test_multi_version_operations_resolve_to_highest(
+    sp_registry: MediaTypeRegistry,
+    method: str,
+    path: str,
+    expected_accept: str,
+) -> None:
+    """Each multi-version op must resolve to its highest declared vN+json."""
+    url = f"https://advertising-api.amazon.com{path}"
+    _, accepts = sp_registry.resolve(method, url)
+    assert accepts is not None, f"registry has no accepts for {method} {path}"
+
+    resolved = resolve_accept(spec_accepts=accepts, existing="*/*")
+    assert resolved == expected_accept, (
+        f"{method} {path}: resolved {resolved!r}, expected {expected_accept!r}\n"
+        f"  spec accepts: {accepts}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR #68 contract — single-version SP v3 entity CRUD must keep resolving to v3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,expected_accept",
+    [
+        # SP v3 campaigns (only v3 declared — highest is v3)
+        (
+            "POST",
+            "/sp/campaigns/list",
+            "application/vnd.spCampaign.v3+json",
+        ),
+        # SP v3 ad groups
+        (
+            "POST",
+            "/sp/adGroups/list",
+            "application/vnd.spAdGroup.v3+json",
+        ),
+        # SP v3 keywords
+        (
+            "POST",
+            "/sp/keywords/list",
+            "application/vnd.spKeyword.v3+json",
+        ),
+        # SP v3 product ads
+        (
+            "POST",
+            "/sp/productAds/list",
+            "application/vnd.spProductAd.v3+json",
+        ),
+    ],
+)
+def test_pr68_single_version_endpoints_unchanged(
+    sp_registry: MediaTypeRegistry,
+    method: str,
+    path: str,
+    expected_accept: str,
+) -> None:
+    """PR #68's wire contract: single-version SP v3 endpoints continue to
+    resolve to the v3 vendored type. Validates that "highest" is correct
+    when only one version is declared."""
+    url = f"https://advertising-api.amazon.com{path}"
+    _, accepts = sp_registry.resolve(method, url)
+    assert accepts is not None
+    resolved = resolve_accept(spec_accepts=accepts, existing="*/*")
+    assert resolved == expected_accept
+
+
+# ---------------------------------------------------------------------------
+# Mixed-base guard — iterate every op, never crash
+# ---------------------------------------------------------------------------
+
+
+def test_no_operation_in_spec_crashes_resolver(sp_spec: dict) -> None:
+    """Walk every operation in the SponsoredProducts spec and confirm the
+    resolver returns SOMETHING (a string or None) for every one — never
+    crashes. Catches: malformed accepts lists, mixed-base ops we don't know
+    about yet, parser regressions on real-world content types.
+    """
+    for path, ops in (sp_spec.get("paths") or {}).items():
+        if not isinstance(ops, dict):
+            continue
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            cts = set()
+            for _, resp in (op.get("responses") or {}).items():
+                if isinstance(resp, dict):
+                    cts.update((resp.get("content") or {}).keys())
+            if not cts:
+                continue
+            accepts = sorted(cts)
+            # Every reasonable existing value should produce SOMETHING (str|None)
+            for existing in (None, "*/*", "application/json"):
+                result = resolve_accept(
+                    spec_accepts=accepts, existing=existing
+                )
+                assert result is None or isinstance(result, str), (
+                    f"{method.upper()} {path} existing={existing!r}: "
+                    f"got {type(result).__name__}"
+                )
+
+
+def test_mixed_base_operations_fall_back_to_first_listed(sp_spec: dict) -> None:
+    """Find every operation in the spec whose accepts list contains more
+    than one distinct base. Today: at least the
+    `spproductrecommendationresponse.asins` / `…themes` op exists. Assert
+    the picker abstains and rule 4 returns first-listed (after registry's
+    lexical sort). Catches: future regressions where someone implements
+    "highest per base" and breaks this contract.
+    """
+    found_any = False
+    for path, ops in (sp_spec.get("paths") or {}).items():
+        if not isinstance(ops, dict):
+            continue
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            cts = set()
+            for _, resp in (op.get("responses") or {}).items():
+                if isinstance(resp, dict):
+                    cts.update((resp.get("content") or {}).keys())
+            accepts = sorted(cts)
+
+            # Bucket parsed accepts by base
+            from amazon_ads_mcp.utils.media.accept_resolver import (
+                parse_vendored_json,
+            )
+
+            bases = set()
+            for ct in accepts:
+                p = parse_vendored_json(ct)
+                if p is not None:
+                    bases.add(p[0])
+            if len(bases) <= 1:
+                continue
+
+            found_any = True
+            # Picker abstains
+            assert pick_highest_vendored_json(accepts) is None, (
+                f"{method.upper()} {path}: picker should abstain on "
+                f"{len(bases)} bases ({bases}), but returned a value"
+            )
+            # Resolver falls back to first-listed
+            resolved = resolve_accept(spec_accepts=accepts, existing="*/*")
+            assert resolved == accepts[0], (
+                f"{method.upper()} {path}: expected first-listed "
+                f"{accepts[0]!r}, got {resolved!r}"
+            )
+
+    assert found_any, (
+        "expected at least one mixed-base operation in current SP spec "
+        "(e.g. spproductrecommendationresponse.asins/themes); spec may have "
+        "changed shape — re-verify before relaxing this assertion"
+    )


### PR DESCRIPTION
## Summary

Closes #70 — the second half of the SP v3 415 fix shipped in PR #68. PR #68 fixed the **415** (Accept never set to a vendored type because httpx default `*/*` suppressed the override). This PR fixes the **500** that follows when the spec declares multiple vendored versions and the registry's "first-vendored" picker silently took v3 instead of the version Amazon's gateway currently expects.

PR #68 + this PR together solve both halves of the original bug class.

## Headline regression fix

`sp_getRankedKeywordRecommendation` now resolves to `application/vnd.spkeywordsrecommendation.v5+json` (was v3 = HTTP 500). 11 more SP operations across 5 distinct content-type families benefit from the same fix.

## Coverage matrix (verified end-to-end against shipped specs)

After review feedback, validation expanded beyond SponsoredProducts to every spec the resolver actually affects. Counts independently re-verified by walking each spec directly.

| Spec | Multi-version single-base | Mixed-base | Tested | Notes |
|---|---|---|---|---|
| `SponsoredProducts.json` | 12 | 1 (asins/themes) | ✓ all 13 | Headline fix + PR #68 contract preserved |
| `AmazonDSPConversions.json` | **2** | **1** | ✓ all 3 | v1 → v2 upgrade verified for the 2 single-base ops; mixed-base abstention verified |
| `AmazonDSPMeasurement.json` | **20** | 0 | ✓ all 20 | All explicit rows committed; ~1.3 max version across measurement, study management, surveys, vendor products |
| `BrandMetrics.json` | 0 single-base | **2** mixed-base | ✓ all 2 | `insightsbrandmetrics` + `insightsbrandmetricserror` in one accepts list; resolver returns lexical-first per documented contract |
| `ReportingVersion3.json` | 0 | 0 | sanity scan | Single-version only; one parameterized assertion across all ops |

Plus a generalized crash walk parametrized across all 5 specs and a wire-path test through real `AuthenticatedClient.send` against `AmazonDSPConversions.json` with a fully mocked auth manager.

## Implementation

**New module** `src/amazon_ads_mcp/utils/media/accept_resolver.py` (192 lines) — pure-function `resolve_accept()` with a documented 7-rule policy table:

1. Caller-pinned vendored Accept preserved unconditionally (PR #68's escape hatch)
2. Vendored intersection of `download_overrides` and `spec_accepts` wins (download contract is more specific)
3. Highest single-base vendored JSON from spec (the headline fix)
4. First vendored from spec when no JSON to compare (handles xlsx mime, brand-specific binaries)
5. First-listed spec value when nothing vendored / mixed bases (caller must pin to disambiguate)
6. Download-only fallback when no spec accepts
7. Otherwise leave alone

`parse_vendored_json` widened to support compound bases real specs use:
- `vnd.spproductrecommendationresponse.asins.v3+json` ✓
- `vnd.SponsoredBrands.SponsoredBrandsMigrationApi.v4+json` ✓
- `vnd.some-base.v2+json` and `vnd.some_base.v2+json` ✓

`pick_highest_vendored_json` abstains on mixed bases so the resolver falls through to first-listed instead of silently picking one shape over another (e.g. asins vs themes, or `metrics` vs `metricserror`). Documented in `test_brandmetrics_mixed_base_returns_first_listed` and `test_dsp_conversions_mixed_base_falls_back_to_first_listed`.

**`_inject_headers` collapsed.** The two parallel Accept-handling blocks from the PR #68 era (`http_client.py:521-577`) are now one `resolve_accept()` call. Same wire contract, one decision point. `-49 / +22` lines.

## Validation matrix

| Layer | Cases | Result |
|---|---|---|
| Unit (pure-function resolver) | 50 | ✓ all pass |
| Spec-contract (real registry, 5 specs) | 48 | ✓ all pass |
| PR #68 wire-contract (preserved verbatim) | 4 | ✓ all pass |
| `test_authenticated_client` (incl. previously-regressing `test_media_type_negotiation`) | 6 | ✓ all pass |
| **DSP wire-path (new file `test_authenticated_client_dsp_wire.py`)** | **2** | **✓ all pass** |
| Slow/wheel-marker | 1 | ✓ pass |
| Integration suite | 61 (+1 skip) | ✓ all pass |
| **Full pytest suite** | **957 (+2 pre-existing skip)** | **✓ no regressions** |
| Ruff lint | — | ✓ clean |

## End-to-end smoke results (manual, run before commit)

Real `AuthenticatedClient.send()` invoked for 15 cases against `dist/openapi/resources/SponsoredProducts.json`; `httpx.AsyncClient.send` patched to capture the wire Accept value. All 15/15 pass. Headline cases verified:

- `getRankedKeywordRecommendation` → `vnd.spkeywordsrecommendation.v5+json` ✓
- All 12 SP multi-version operations resolve to highest declared version ✓
- All 4 SP v3 entity CRUD operations unchanged at v3 (PR #68 contract) ✓
- Caller-pinned `vnd.sptargetpromotiongroup.v1+json` preserved (rule 1 escape hatch) ✓

The DSP wire-path test (`tests/integration/test_authenticated_client_dsp_wire.py`) provides the same assurance for DSP in CI permanently.

## TDD-driven, real bugs caught during implementation

1. `test_media_type_negotiation` regression caught when "highest vendored JSON" silently broke non-version vendored types like xlsx mime — drove rule 4 design.
2. Mixed-base spec-contract test caught that rule 4 was too greedy — silently picked `asins` over `themes` for ops that genuinely require the caller to pin — drove the `has_vendored_json` differentiation between "abstained because no JSON" and "abstained because mixed bases."
3. Coverage gap review caught that initial validation tested only 1 of 5 affected specs. Independent spec walk corrected counts (DSP Measurement = 20, not the 13 originally cited; BrandMetrics in scope, not "sanity-only").

None would have been caught by the original PR #68 tests. All are now locked.

## Audit helper

`scripts/dump_multi_version_ops.py` — standalone utility (not pytest-imported) that walks `dist/openapi/resources/` and prints `(method, path, expected_accept)` rows. Used to author initial test rows AND to refresh expectations after spec regen. Test rows in test files are the source of truth; the script is the audit aid for maintenance.

```bash
uv run python scripts/dump_multi_version_ops.py --spec AmazonDSPMeasurement
```

## Design discipline

Per `docs/roadmap/unified-accept-resolver.md` ("Design discipline" section), this PR is **fully spec-driven**:

- The picker reads what the spec declares; no per-operation overrides anywhere
- No hand-curated `transform.json.accept_override` field — explicitly rejected during planning
- Tools that need a specific version pin Accept at the call site (preserved by caller-pinned rule 1)
- The resolver works against any `MediaTypeRegistry` data source — unit tests inject `accepts` directly so PR 1 (this) and PR 2 (sidecar restoration) remain independent

## Out of scope (tracked separately)

- **Phase 2 sidecar restoration** — fix the half-implemented `*.media.json` generator + loader so the sidecars actually contribute data; add parity tests as the drift guardrail. Roadmap doc has full PR 2 acceptance criteria.
- **Aggressive spec slimming** — separate roadmap item, after Phase 2 completes.
- **Modifying `resolve_download_accept_headers`** — its hardcoded v1 vendored types are a separate concern; this PR validates the resolver's rule 2 intersection works correctly against the values it produces, not that those values are themselves up-to-date.

## Test plan

- [ ] Confirm CI runs `uv run pytest` and reports 957 passing
- [ ] Confirm ruff check clean
- [ ] (Optional) Live-wire smoke against an Amazon Ads sandbox for `sp_getRankedKeywordRecommendation` — verifies upstream gateway behavior matches our spec-driven assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)
