### PR TITLE
feat(campaigns): SP v3 write tools + full archive endpoint coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,8 @@ profile_output/
 # MCP Registry tokens
 .mcpregistry_*
 dfg.txt
+
+# Local pre-flight stash — batch operation receipts (campaign IDs, target
+# lists). Per the 6AM batch-preview lesson: stashed locally before any live
+# mutation so reversal is a file read, not an API re-query. Never committed.
+.batch-stash/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/NOTE-TOKENS.md
+++ b/NOTE-TOKENS.md
@@ -1,0 +1,20 @@
+# Token Sources
+
+This repo uses two refresh-token sources. Knowing which is active matters.
+
+## ~/.claude.json (runtime — DEFAULT for the MCP server)
+- Active profile for Marketing / PPC work: PBN (Photo Booth Nook), profile_id 3987763286122956.
+- The MCP server loads from this file at startup.
+- All MCP tool calls (campaign reads, negative-keyword updates, etc.) use this token.
+
+## .env at project root (RDO testing context — secondary)
+- Refresh token for Rusty Dog Outdoors (3 profiles, none of which is PBN).
+- Purpose unclear (Craig has not touched this file). Possibly stale, possibly intentional for RDO-specific testing.
+- **Helper scripts that need PBN access must NOT load this .env.** Helper scripts should either rely on the MCP runtime token (preferred — call the MCP tools instead of raw API) or explicitly load from ~/.claude.json.
+
+## Pattern to follow
+- **Default to MCP tool calls** for all Amazon Ads API access. The MCP handles token sourcing and endpoint shape correctly.
+- Avoid raw httpx in helper scripts — past bugs (SP v3 expression-type case mismatch, GET /v2/portfolios endpoint shape) lived in helper scripts that bypassed the MCP. See `src/amazon_ads_mcp/utils/sp_enum_normalize.py` (commit 2b506a2) for the SP v3 normalization helper that should be imported by any script that does need to parse response types.
+
+---
+*Created 2026-05-05 during a Marketing weekly review session that surfaced the token-source split. Source: Rusty Dog Brands Cowork PPC pipeline.*

--- a/NOTE-TOKENS.md
+++ b/NOTE-TOKENS.md
@@ -1,16 +1,49 @@
 # Token Sources
 
-This repo uses two refresh-token sources. Knowing which is active matters.
+This repo uses two refresh-token sources, one per brand. Two MCP server entries
+in `~/.claude.json` (`amazon-ads` for PBN, `amazon-ads-sh` for SH) load them
+side-by-side so both brands are reachable in the same Claude Code session.
 
-## ~/.claude.json (runtime — DEFAULT for the MCP server)
-- Active profile for Marketing / PPC work: PBN (Photo Booth Nook), profile_id 3987763286122956.
-- The MCP server loads from this file at startup.
-- All MCP tool calls (campaign reads, negative-keyword updates, etc.) use this token.
+## ~/.claude.json `amazon-ads` entry → PBN
+- Refresh token for Photo Booth Nook.
+- Default profile: 3987763286122956 (PBN US seller).
+- Also covers PBN CA seller (profile 2560467967906921) — same token, just switch
+  active_profile.
+- Tools surface as `mcp__amazon-ads__*`.
 
-## .env at project root (RDO testing context — secondary)
-- Refresh token for Rusty Dog Outdoors (3 profiles, none of which is PBN).
-- Purpose unclear (Craig has not touched this file). Possibly stale, possibly intentional for RDO-specific testing.
-- **Helper scripts that need PBN access must NOT load this .env.** Helper scripts should either rely on the MCP runtime token (preferred — call the MCP tools instead of raw API) or explicitly load from ~/.claude.json.
+## ~/.claude.json `amazon-ads-sh` entry → SH
+- Refresh token for Sap Happy Sugarin' Supplies.
+- Default profile: 3778622964304303 (SH US seller).
+- Also covers SH CA (1018256446748374) and SH MX (351892444800497) — same
+  token, just switch active_profile.
+- Tools surface as `mcp__amazon-ads-sh__*`.
+
+### CRITICAL GOTCHA — "Rusty Dog Outdoors" label is SH
+
+When you call `/v2/profiles` with the SH token, every profile comes back with
+`accountInfo.name = 'Rusty Dog Outdoors'`. That's the original account name
+Craig set when creating the SH Seller Central account; Amazon will not let him
+rename it. **It is still SH.** Do not let the `accountInfo.name` mislead you
+into thinking these are RDO profiles — RDO is a separate brand that does not
+have its own Amazon Ads presence.
+
+## .env at project root
+- Originally held the SH refresh token under the misleading "RDO" framing.
+- Now redundant: `~/.claude.json` `amazon-ads-sh` entry is the source of truth.
+- Kept on disk as a backup; do not load from helper scripts. Use the MCP tools
+  instead, namespaced by brand.
+
+## Pattern to follow
+- **Default to MCP tool calls** for all Amazon Ads API access. The MCP handles
+  token sourcing, region routing, and endpoint shape correctly.
+- For PBN work, use `mcp__amazon-ads__*` tools. For SH work, use
+  `mcp__amazon-ads-sh__*` tools. Pick the right server before acting — the
+  namespacing prevents cross-brand mistakes.
+- Avoid raw httpx in helper scripts — past bugs (SP v3 expression-type case
+  mismatch, GET /v2/portfolios endpoint shape) lived in helper scripts that
+  bypassed the MCP. See `src/amazon_ads_mcp/utils/sp_enum_normalize.py` (commit
+  2b506a2) for the SP v3 normalization helper that should be imported by any
+  script that does need to parse response types.
 
 ## Pattern to follow
 - **Default to MCP tool calls** for all Amazon Ads API access. The MCP handles token sourcing and endpoint shape correctly.

--- a/negation_batches/execute_negation_batch.py
+++ b/negation_batches/execute_negation_batch.py
@@ -1,0 +1,228 @@
+"""Execute ad-group-level negative keyword + negative product target batches
+for PBN cross-family negation plan.
+
+Reads plan from plan_{ts}.json. Writes results to results_{ts}.json.
+Uses the amazon-ads-mcp auth machinery (same LWA credentials as MCP server).
+
+Pass --dry-run to preview outgoing payloads without sending anything to Amazon.
+"""
+
+import argparse
+import asyncio
+import datetime
+import json
+from pathlib import Path
+
+NEG_KW_CT = "application/vnd.spNegativeKeyword.v3+json"
+NEG_TGT_CT = "application/vnd.spNegativeTargetingClause.v3+json"
+
+
+def _build_neg_kw_body(campaign_id, ad_group_id, terms, match_type):
+    return {
+        "negativeKeywords": [
+            {
+                "campaignId": campaign_id,
+                "adGroupId": ad_group_id,
+                "keywordText": t,
+                "matchType": match_type,
+                "state": "ENABLED",
+            }
+            for t in terms
+        ]
+    }
+
+
+def _build_neg_tgt_body(campaign_id, ad_group_id, asins):
+    return {
+        "negativeTargetingClauses": [
+            {
+                "campaignId": campaign_id,
+                "adGroupId": ad_group_id,
+                "expression": [{"type": "ASIN_SAME_AS", "value": a}],
+                "state": "ENABLED",
+            }
+            for a in asins
+        ]
+    }
+
+
+def _print_dry_run(method, endpoint, body):
+    print(f"    [DRY-RUN] {method} {endpoint}")
+    for line in json.dumps(body, indent=2).splitlines():
+        print(f"    {line}")
+
+
+def _safe_json(resp):
+    """Parse a response body as JSON, falling back to a text snapshot.
+
+    Amazon/proxy failures periodically return HTML or plain text (WAF
+    blocks, 5xx gateway pages). Calling resp.json() on those bodies
+    raises json.JSONDecodeError mid-loop; with partial negatives already
+    applied, the run then crashes before any results file is written.
+    Return a structured fallback dict instead so the caller can record
+    the failure and keep going.
+    """
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError) as e:
+        return {
+            "parse_error": f"{type(e).__name__}: {e}",
+            "raw_body": (resp.text or "")[:2000],
+        }
+
+
+def _write_results(results_file, results):
+    Path(results_file).write_text(json.dumps(results, indent=2, default=str))
+
+
+async def create_negative_keywords(client, campaign_id, ad_group_id, terms, match_type, dry_run=False):
+    """match_type: NEGATIVE_PHRASE or NEGATIVE_EXACT."""
+    if not terms:
+        return {"attempted": 0, "success": [], "error": []}
+    body = _build_neg_kw_body(campaign_id, ad_group_id, terms, match_type)
+    if dry_run:
+        _print_dry_run("POST", "/sp/negativeKeywords", body)
+        return {"attempted": len(terms), "dry_run": True, "success": [], "error": []}
+    resp = await client.post(
+        "/sp/negativeKeywords",
+        json=body,
+        headers={"Accept": NEG_KW_CT, "Content-Type": NEG_KW_CT},
+    )
+    raw = _safe_json(resp)
+    if resp.status_code not in (200, 207):
+        return {
+            "attempted": len(terms),
+            "http_status": resp.status_code,
+            "success": [],
+            "error": [{"message": f"HTTP {resp.status_code}", "body": raw}],
+        }
+    # V3 response: {"negativeKeywords": {"success": [...], "error": [...]}}
+    wrap = raw.get("negativeKeywords", {}) if isinstance(raw, dict) else {}
+    return {
+        "attempted": len(terms),
+        "http_status": resp.status_code,
+        "success": wrap.get("success", []),
+        "error": wrap.get("error", []),
+    }
+
+
+async def create_negative_asin_targets(client, campaign_id, ad_group_id, asins, dry_run=False):
+    if not asins:
+        return {"attempted": 0, "success": [], "error": []}
+    body = _build_neg_tgt_body(campaign_id, ad_group_id, asins)
+    if dry_run:
+        _print_dry_run("POST", "/sp/negativeTargets", body)
+        return {"attempted": len(asins), "dry_run": True, "success": [], "error": []}
+    resp = await client.post(
+        "/sp/negativeTargets",
+        json=body,
+        headers={"Accept": NEG_TGT_CT, "Content-Type": NEG_TGT_CT},
+    )
+    raw = _safe_json(resp)
+    if resp.status_code not in (200, 207):
+        return {
+            "attempted": len(asins),
+            "http_status": resp.status_code,
+            "success": [],
+            "error": [{"message": f"HTTP {resp.status_code}", "body": raw}],
+        }
+    wrap = raw.get("negativeTargetingClauses", {}) if isinstance(raw, dict) else {}
+    return {
+        "attempted": len(asins),
+        "http_status": resp.status_code,
+        "success": wrap.get("success", []),
+        "error": wrap.get("error", []),
+    }
+
+
+async def main(plan_file, dry_run):
+    plan = json.load(open(plan_file))
+    client = None
+    if not dry_run:
+        # Only import + init the HTTP client when we actually need to send.
+        # Standalone bootstrap — the module-level singleton populated by
+        # ServerBuilder.build() does not exist when this CLI runs directly.
+        from amazon_ads_mcp.utils.http_client import bootstrap_standalone_client
+        client = await bootstrap_standalone_client()
+
+    results = {
+        "plan_file": str(Path(plan_file).name),
+        "executed_at_utc": datetime.datetime.utcnow().isoformat() + "Z",
+        "dry_run": dry_run,
+        "campaigns": [],
+    }
+    counts = {"NEGATIVE_PHRASE": 0, "NEGATIVE_EXACT": 0, "NEGATIVE_ASIN": 0}
+
+    # Write an empty results file up front so a mid-loop crash still
+    # leaves a recoverable audit trail. Subsequent per-campaign writes
+    # overwrite this file with progressively more complete state.
+    results_file = None
+    if not dry_run:
+        results_file = str(plan_file).replace("plan_", "results_")
+        _write_results(results_file, results)
+
+    for c in plan["campaigns"]:
+        print(f"\n>>> {c['name']}")
+        entry = {
+            "name": c["name"],
+            "campaign_id": c["campaign_id"],
+            "ad_group_id": c["ad_group_id"],
+        }
+        if c.get("phrase_negatives"):
+            r = await create_negative_keywords(
+                client, c["campaign_id"], c["ad_group_id"],
+                c["phrase_negatives"], "NEGATIVE_PHRASE", dry_run=dry_run,
+            )
+            entry["phrase"] = r
+            counts["NEGATIVE_PHRASE"] += r["attempted"]
+            if not dry_run:
+                print(f"  PHRASE: attempted={r['attempted']} success={len(r['success'])} errors={len(r['error'])}")
+                for e in r["error"]:
+                    print(f"    err: {e}")
+        if c.get("exact_negatives"):
+            r = await create_negative_keywords(
+                client, c["campaign_id"], c["ad_group_id"],
+                c["exact_negatives"], "NEGATIVE_EXACT", dry_run=dry_run,
+            )
+            entry["exact"] = r
+            counts["NEGATIVE_EXACT"] += r["attempted"]
+            if not dry_run:
+                print(f"  EXACT : attempted={r['attempted']} success={len(r['success'])} errors={len(r['error'])}")
+                for e in r["error"]:
+                    print(f"    err: {e}")
+        if c.get("negative_asins"):
+            r = await create_negative_asin_targets(
+                client, c["campaign_id"], c["ad_group_id"], c["negative_asins"], dry_run=dry_run,
+            )
+            entry["asin_targets"] = r
+            counts["NEGATIVE_ASIN"] += r["attempted"]
+            if not dry_run:
+                print(f"  ASIN  : attempted={r['attempted']} success={len(r['success'])} errors={len(r['error'])}")
+                for e in r["error"]:
+                    print(f"    err: {e}")
+        results["campaigns"].append(entry)
+        if results_file is not None:
+            # Persist after each campaign so a network/JSON failure on the
+            # next iteration still leaves an audit trail on disk.
+            _write_results(results_file, results)
+
+    if dry_run:
+        print("\n=== DRY-RUN SUMMARY — nothing sent to Amazon ===")
+        print(f"  NEGATIVE_PHRASE payloads: {counts['NEGATIVE_PHRASE']}")
+        print(f"  NEGATIVE_EXACT  payloads: {counts['NEGATIVE_EXACT']}")
+        print(f"  NEGATIVE_ASIN   payloads: {counts['NEGATIVE_ASIN']}")
+        print(f"  TOTAL would-be API objects: {sum(counts.values())}")
+    else:
+        print(f"\nResults written to {results_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("plan_file", help="Path to plan_{ts}.json")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print outgoing payloads without sending to Amazon; skip results file write.",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(args.plan_file, args.dry_run))

--- a/src/amazon_ads_mcp/models/builtin_responses.py
+++ b/src/amazon_ads_mcp/models/builtin_responses.py
@@ -755,3 +755,363 @@ ReportFieldsResponse = Annotated[
     Union[QueryReportFieldsResponse, ValidateReportFieldsResponse],
     Field(discriminator="mode"),
 ]
+
+
+# ============================================================================
+# Campaign Management Tool Responses
+# ============================================================================
+
+
+class UpdateCampaignResponse(BaseModel):
+    """Response from update_sp_campaigns / update_sb_campaigns tools.
+
+    :param success: Whether the update succeeded
+    :param campaign_id: Campaign ID that was updated
+    :param message: Human-readable status message
+    :param updated_fields: Fields that were changed
+    :param details: Raw API response details
+    :param error: Error details if failed
+    """
+
+    success: bool
+    campaign_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateAdGroupResponse(BaseModel):
+    """Response from update_sp_ad_groups tool.
+
+    :param success: Whether the update succeeded
+    :param ad_group_id: Ad group ID that was updated
+    :param message: Human-readable status message
+    :param updated_fields: Fields that were changed
+    :param details: Raw API response details
+    :param error: Error details if failed
+    """
+
+    success: bool
+    ad_group_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateKeywordResponse(BaseModel):
+    """Response from update_sp_keywords tool.
+
+    :param success: Whether the update succeeded
+    :param keyword_id: Keyword ID that was updated
+    :param message: Human-readable status message
+    :param updated_fields: Fields that were changed
+    :param details: Raw API response details
+    :param error: Error details if failed
+    """
+
+    success: bool
+    keyword_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateProductAdResponse(BaseModel):
+    """Response from update_sp_product_ads tool.
+
+    :param success: Whether the update succeeded
+    :param ad_id: Product ad ID that was updated
+    :param message: Human-readable status message
+    :param updated_fields: Fields that were changed
+    :param details: Raw API response details
+    :param error: Error details if failed
+    """
+
+    success: bool
+    ad_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class AdGroupItem(BaseModel):
+    """Single ad group in a list response.
+
+    :param ad_group_id: Ad group ID
+    :param name: Ad group name
+    :param campaign_id: Parent campaign ID
+    :param state: Current state
+    :param default_bid: Default bid amount
+    """
+
+    ad_group_id: Optional[str] = None
+    name: Optional[str] = None
+    campaign_id: Optional[str] = None
+    state: Optional[str] = None
+    default_bid: Optional[float] = None
+
+
+class ListAdGroupsResponse(BaseModel):
+    """Response from list_sp_ad_groups tool.
+
+    :param success: Whether the request succeeded
+    :param items: List of ad groups
+    :param count: Number of items returned
+    :param next_token: Pagination token for next page
+    :param error: Error message if failed
+    """
+
+    success: bool
+    items: List[AdGroupItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+class KeywordItem(BaseModel):
+    """Single keyword in a list response.
+
+    :param keyword_id: Keyword ID
+    :param keyword_text: The keyword text
+    :param match_type: Match type (BROAD, PHRASE, EXACT)
+    :param campaign_id: Parent campaign ID
+    :param ad_group_id: Parent ad group ID
+    :param state: Current state
+    :param bid: Current bid amount
+    """
+
+    keyword_id: Optional[str] = None
+    keyword_text: Optional[str] = None
+    match_type: Optional[str] = None
+    campaign_id: Optional[str] = None
+    ad_group_id: Optional[str] = None
+    state: Optional[str] = None
+    bid: Optional[float] = None
+
+
+class ListKeywordsResponse(BaseModel):
+    """Response from list_sp_keywords tool.
+
+    :param success: Whether the request succeeded
+    :param items: List of keywords
+    :param count: Number of items returned
+    :param next_token: Pagination token for next page
+    :param error: Error message if failed
+    """
+
+    success: bool
+    items: List[KeywordItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+class CreateCampaignResponse(BaseModel):
+    success: bool
+    campaign_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class CreateAdGroupResponse(BaseModel):
+    success: bool
+    ad_group_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class CreateKeywordResponse(BaseModel):
+    success: bool
+    keyword_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class CreateProductAdResponse(BaseModel):
+    success: bool
+    ad_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class CampaignItem(BaseModel):
+    campaign_id: Optional[str] = None
+    name: Optional[str] = None
+    state: Optional[str] = None
+    targeting_type: Optional[str] = None
+    budget_amount: Optional[float] = None
+    budget_type: Optional[str] = None
+    portfolio_id: Optional[str] = None
+    start_date: Optional[str] = None
+    bidding_strategy: Optional[str] = None
+    placement_top_pct: Optional[float] = 0
+    placement_product_page_pct: Optional[float] = 0
+    placement_rest_of_search_pct: Optional[float] = 0
+
+
+class ListCampaignsResponse(BaseModel):
+    success: bool
+    items: List[CampaignItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+class ProductAdItem(BaseModel):
+    ad_id: Optional[str] = None
+    campaign_id: Optional[str] = None
+    ad_group_id: Optional[str] = None
+    asin: Optional[str] = None
+    state: Optional[str] = None
+
+
+class ListProductAdsResponse(BaseModel):
+    success: bool
+    items: List[ProductAdItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Portfolios
+# ---------------------------------------------------------------------------
+
+class PortfolioItem(BaseModel):
+    portfolio_id: Optional[str] = None
+    name: Optional[str] = None
+    state: Optional[str] = None
+    in_budget: Optional[bool] = None
+    budget_policy: Optional[str] = None
+    budget_currency: Optional[str] = None
+
+
+class ListPortfoliosResponse(BaseModel):
+    success: bool
+    items: List[PortfolioItem] = Field(default_factory=list)
+    count: int = 0
+    total_results: Optional[int] = None
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Campaign negative keywords
+# ---------------------------------------------------------------------------
+
+class CreateNegativeKeywordResponse(BaseModel):
+    success: bool
+    keyword_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateNegativeKeywordResponse(BaseModel):
+    success: bool
+    keyword_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class NegativeKeywordItem(BaseModel):
+    keyword_id: Optional[str] = None
+    keyword_text: Optional[str] = None
+    match_type: Optional[str] = None
+    campaign_id: Optional[str] = None
+    state: Optional[str] = None
+
+
+class ListNegativeKeywordsResponse(BaseModel):
+    success: bool
+    items: List[NegativeKeywordItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Targeting clauses (targets)
+# ---------------------------------------------------------------------------
+
+class CreateTargetResponse(BaseModel):
+    success: bool
+    target_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateTargetResponse(BaseModel):
+    success: bool
+    target_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class TargetItem(BaseModel):
+    target_id: Optional[str] = None
+    campaign_id: Optional[str] = None
+    ad_group_id: Optional[str] = None
+    expression: Optional[List[Dict[str, Any]]] = None
+    resolved_expression: Optional[List[Dict[str, Any]]] = None
+    expression_type: Optional[str] = None
+    state: Optional[str] = None
+    bid: Optional[float] = None
+
+
+class ListTargetsResponse(BaseModel):
+    success: bool
+    items: List[TargetItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Campaign negative targets
+# ---------------------------------------------------------------------------
+
+class CreateNegativeTargetResponse(BaseModel):
+    success: bool
+    target_id: Optional[str] = None
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class UpdateNegativeTargetResponse(BaseModel):
+    success: bool
+    target_id: str
+    message: str
+    updated_fields: Optional[Dict[str, Any]] = None
+    details: Optional[Dict[str, Any]] = None
+    error: Optional[Any] = None
+
+
+class NegativeTargetItem(BaseModel):
+    target_id: Optional[str] = None
+    campaign_id: Optional[str] = None
+    expression: Optional[List[Dict[str, Any]]] = None
+    resolved_expression: Optional[List[Dict[str, Any]]] = None
+    state: Optional[str] = None
+
+
+class ListNegativeTargetsResponse(BaseModel):
+    success: bool
+    items: List[NegativeTargetItem] = Field(default_factory=list)
+    count: int = 0
+    next_token: Optional[str] = None
+    error: Optional[str] = None

--- a/src/amazon_ads_mcp/models/builtin_responses.py
+++ b/src/amazon_ads_mcp/models/builtin_responses.py
@@ -955,6 +955,13 @@ class CampaignItem(BaseModel):
     placement_top_pct: Optional[float] = 0
     placement_product_page_pct: Optional[float] = 0
     placement_rest_of_search_pct: Optional[float] = 0
+    # Populated only when list_sp_campaigns is called with
+    # include_extended_data=True. servingStatus is the delivery health
+    # signal (e.g. CAMPAIGN_OUT_OF_BUDGET, CAMPAIGN_STATUS_ENABLED).
+    serving_status: Optional[str] = None
+    serving_status_details: Optional[List[Dict[str, Any]]] = None
+    creation_date_time: Optional[str] = None
+    last_update_date_time: Optional[str] = None
 
 
 class ListCampaignsResponse(BaseModel):

--- a/src/amazon_ads_mcp/models/builtin_responses.py
+++ b/src/amazon_ads_mcp/models/builtin_responses.py
@@ -962,6 +962,12 @@ class CampaignItem(BaseModel):
     serving_status_details: Optional[List[Dict[str, Any]]] = None
     creation_date_time: Optional[str] = None
     last_update_date_time: Optional[str] = None
+    # Full extendedData object as returned by the API. Lossless passthrough
+    # so future fields Amazon adds aren't silently dropped — the flattened
+    # convenience keys above are duplicated from this blob. None when
+    # include_extended_data was not requested or the API returned no
+    # extendedData on the campaign.
+    extended_data: Optional[Dict[str, Any]] = None
 
 
 class ListCampaignsResponse(BaseModel):

--- a/src/amazon_ads_mcp/models/builtin_responses.py
+++ b/src/amazon_ads_mcp/models/builtin_responses.py
@@ -1042,6 +1042,7 @@ class NegativeKeywordItem(BaseModel):
     keyword_text: Optional[str] = None
     match_type: Optional[str] = None
     campaign_id: Optional[str] = None
+    ad_group_id: Optional[str] = None
     state: Optional[str] = None
 
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1595,7 +1595,12 @@ async def register_campaign_management_tools(server: FastMCP):
 
     @server.tool(
         name="list_sp_campaigns",
-        description="List Sponsored Products campaigns, optionally filtered by name, state, or portfolio",
+        description=(
+            "List Sponsored Products campaigns, optionally filtered by name, state, or portfolio. "
+            "Pass include_extended_data=true to surface serving_status (e.g. CAMPAIGN_OUT_OF_BUDGET, "
+            "CAMPAIGN_STATUS_ENABLED), serving_status_details, creation_date_time, and "
+            "last_update_date_time on each item. Off by default to keep responses small."
+        ),
     )
     async def list_sp_campaigns_tool(
         ctx: Context,
@@ -1604,6 +1609,7 @@ async def register_campaign_management_tools(server: FastMCP):
         portfolio_id_filter: Optional[str] = None,
         max_results: int = 100,
         next_token: Optional[str] = None,
+        include_extended_data: bool = False,
     ) -> ListCampaignsResponse:
         _require_active_profile()
         result = await campaign_management.list_sp_campaigns(
@@ -1612,6 +1618,7 @@ async def register_campaign_management_tools(server: FastMCP):
             portfolio_id_filter=portfolio_id_filter,
             max_results=max_results,
             next_token=next_token,
+            include_extended_data=include_extended_data,
         )
         return ListCampaignsResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1597,9 +1597,13 @@ async def register_campaign_management_tools(server: FastMCP):
         name="list_sp_campaigns",
         description=(
             "List Sponsored Products campaigns, optionally filtered by name, state, or portfolio. "
-            "Pass include_extended_data=true to surface serving_status (e.g. CAMPAIGN_OUT_OF_BUDGET, "
-            "CAMPAIGN_STATUS_ENABLED), serving_status_details, creation_date_time, and "
-            "last_update_date_time on each item. Off by default to keep responses small."
+            "Pass include_extended_data=true to return campaign serving status (e.g. "
+            "CAMPAIGN_OUT_OF_BUDGET, CAMPAIGN_STATUS_ENABLED, ENDED, CAMPAIGN_PAUSED, "
+            "CAMPAIGN_ARCHIVED, ADVERTISER_OUT_OF_BUDGET, PORTFOLIO_OUT_OF_BUDGET) via "
+            "extendedData.servingStatus. Each item also gets flattened convenience keys "
+            "(serving_status, serving_status_details, creation_date_time, "
+            "last_update_date_time) and a full extended_data passthrough so future fields "
+            "Amazon adds are never silently dropped. Off by default to keep responses small."
         ),
     )
     async def list_sp_campaigns_tool(

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -19,7 +19,7 @@ Examples
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from fastmcp import Context, FastMCP
 
@@ -30,6 +30,13 @@ from ..config.settings import settings
 from ..middleware.auth_session_bridge import compute_session_state
 from ..models.builtin_responses import (
     ClearProfileResponse,
+    CreateAdGroupResponse,
+    CreateCampaignResponse,
+    CreateKeywordResponse,
+    CreateNegativeKeywordResponse,
+    CreateNegativeTargetResponse,
+    CreateProductAdResponse,
+    CreateTargetResponse,
     DownloadedFile,
     DownloadExportResponse,
     EnableToolGroupResponse,
@@ -38,9 +45,17 @@ from ..models.builtin_responses import (
     GetProfileResponse,
     GetRegionResponse,
     GetSessionStateResponse,
+    ListAdGroupsResponse,
+    ListCampaignsResponse,
     ListDownloadsResponse,
+    ListKeywordsResponse,
+    ListNegativeKeywordsResponse,
+    ListNegativeTargetsResponse,
+    ListPortfoliosResponse,
+    ListProductAdsResponse,
     ListReportFieldsResponse,
     ListRegionsResponse,
+    ListTargetsResponse,
     ProfileSelectorResponse,
     ProfilePageResponse,
     ProfileCacheRefreshResponse,
@@ -54,7 +69,15 @@ from ..models.builtin_responses import (
     SetRegionResponse,
     ToolGroupInfo,
     ToolGroupsResponse,
+    UpdateAdGroupResponse,
+    UpdateCampaignResponse,
+    UpdateKeywordResponse,
+    UpdateNegativeKeywordResponse,
+    UpdateNegativeTargetResponse,
+    UpdateProductAdResponse,
+    UpdateTargetResponse,
 )
+from ..tools import campaign_management
 from ..tools import identity, profile, profile_listing
 from ..tools import report_fields
 from ..tools import region as region_module
@@ -1295,6 +1318,542 @@ async def register_sampling_tools(server: FastMCP):
             )
 
 
+def _require_active_profile() -> None:
+    """Raise ValueError if no active profile is set.
+
+    Mirrors the precondition already enforced by the download tools
+    (see ``download_export_tool``). Without this guard, campaign-
+    management writes silently fall through to whatever default
+    profile the auth layer resolves, which can misroute mutations
+    across brand accounts (e.g. PBN ↔ SH).
+    """
+    auth_mgr = get_auth_manager()
+    profile_id = auth_mgr.get_active_profile_id() if auth_mgr else None
+    if not profile_id:
+        raise ValueError(
+            "No active profile set. Call set_active_profile or set_context first."
+        )
+
+
+async def register_campaign_management_tools(server: FastMCP):
+    """Register campaign management (write) tools.
+
+    :param server: FastMCP server instance
+    """
+
+    @server.tool(
+        name="update_sp_campaigns",
+        description=(
+            "Update a Sponsored Products campaign (rename, change budget, "
+            "pause/enable/archive, set placement bid adjustments, set bidding strategy). "
+            "Placement adjustments (placement_top_pct, placement_product_page_pct, "
+            "placement_rest_of_search_pct) are merged: omitted placements retain their "
+            "current value. Each percentage must be 0-900."
+        ),
+    )
+    async def update_sp_campaigns_tool(
+        ctx: Context,
+        campaign_id: str,
+        name: Optional[str] = None,
+        state: Optional[str] = None,
+        budget_amount: Optional[float] = None,
+        budget_type: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        placement_top_pct: Optional[int] = None,
+        placement_product_page_pct: Optional[int] = None,
+        placement_rest_of_search_pct: Optional[int] = None,
+        bidding_strategy: Optional[str] = None,
+    ) -> UpdateCampaignResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_campaigns(
+            campaign_id=campaign_id,
+            name=name,
+            state=state,
+            budget_amount=budget_amount,
+            budget_type=budget_type,
+            start_date=start_date,
+            end_date=end_date,
+            placement_top_pct=placement_top_pct,
+            placement_product_page_pct=placement_product_page_pct,
+            placement_rest_of_search_pct=placement_rest_of_search_pct,
+            bidding_strategy=bidding_strategy,
+        )
+        return UpdateCampaignResponse(**result)
+
+    @server.tool(
+        name="update_sb_campaigns",
+        description="Update a Sponsored Brands campaign (rename, change budget, pause/enable/archive)",
+    )
+    async def update_sb_campaigns_tool(
+        ctx: Context,
+        campaign_id: str,
+        name: Optional[str] = None,
+        state: Optional[str] = None,
+        budget_amount: Optional[float] = None,
+        budget_type: Optional[str] = None,
+    ) -> UpdateCampaignResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sb_campaigns(
+            campaign_id=campaign_id,
+            name=name,
+            state=state,
+            budget_amount=budget_amount,
+            budget_type=budget_type,
+        )
+        return UpdateCampaignResponse(**result)
+
+    @server.tool(
+        name="update_sp_ad_groups",
+        description="Update a Sponsored Products ad group (rename, change default bid, pause/enable/archive)",
+    )
+    async def update_sp_ad_groups_tool(
+        ctx: Context,
+        ad_group_id: str,
+        name: Optional[str] = None,
+        state: Optional[str] = None,
+        default_bid: Optional[float] = None,
+    ) -> UpdateAdGroupResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_ad_groups(
+            ad_group_id=ad_group_id,
+            name=name,
+            state=state,
+            default_bid=default_bid,
+        )
+        return UpdateAdGroupResponse(**result)
+
+    @server.tool(
+        name="update_sp_keywords",
+        description="Update a Sponsored Products keyword (change bid, pause/enable/archive)",
+    )
+    async def update_sp_keywords_tool(
+        ctx: Context,
+        keyword_id: str,
+        state: Optional[str] = None,
+        bid: Optional[float] = None,
+    ) -> UpdateKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_keywords(
+            keyword_id=keyword_id,
+            state=state,
+            bid=bid,
+        )
+        return UpdateKeywordResponse(**result)
+
+    @server.tool(
+        name="update_sp_product_ads",
+        description="Update a Sponsored Products product ad state (pause/enable/archive)",
+    )
+    async def update_sp_product_ads_tool(
+        ctx: Context,
+        ad_id: str,
+        state: Optional[str] = None,
+    ) -> UpdateProductAdResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_product_ads(
+            ad_id=ad_id,
+            state=state,
+        )
+        return UpdateProductAdResponse(**result)
+
+    @server.tool(
+        name="list_sp_ad_groups",
+        description="List Sponsored Products ad groups, optionally filtered by campaign ID and state",
+    )
+    async def list_sp_ad_groups_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListAdGroupsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_ad_groups(
+            campaign_id=campaign_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListAdGroupsResponse(**result)
+
+    @server.tool(
+        name="list_sp_keywords",
+        description="List Sponsored Products keywords, optionally filtered by campaign/ad group and state",
+    )
+    async def list_sp_keywords_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        ad_group_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListKeywordsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_keywords(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListKeywordsResponse(**result)
+
+    @server.tool(
+        name="create_sp_campaign",
+        description="Create a new Sponsored Products campaign",
+    )
+    async def create_sp_campaign_tool(
+        ctx: Context,
+        name: str,
+        targeting_type: str,
+        budget_amount: float,
+        state: str = "ENABLED",
+        portfolio_id: Optional[str] = None,
+        bidding_strategy: str = "LEGACY_FOR_SALES",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> CreateCampaignResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_campaign(
+            name=name,
+            targeting_type=targeting_type,
+            budget_amount=budget_amount,
+            state=state,
+            portfolio_id=portfolio_id,
+            bidding_strategy=bidding_strategy,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        return CreateCampaignResponse(**result)
+
+    @server.tool(
+        name="create_sp_ad_group",
+        description="Create a new Sponsored Products ad group",
+    )
+    async def create_sp_ad_group_tool(
+        ctx: Context,
+        campaign_id: str,
+        name: str,
+        default_bid: float,
+        state: str = "ENABLED",
+    ) -> CreateAdGroupResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_ad_group(
+            campaign_id=campaign_id,
+            name=name,
+            default_bid=default_bid,
+            state=state,
+        )
+        return CreateAdGroupResponse(**result)
+
+    @server.tool(
+        name="create_sp_keyword",
+        description="Create a new Sponsored Products keyword",
+    )
+    async def create_sp_keyword_tool(
+        ctx: Context,
+        campaign_id: str,
+        ad_group_id: str,
+        keyword_text: str,
+        match_type: str,
+        bid: float,
+        state: str = "ENABLED",
+    ) -> CreateKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_keyword(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            keyword_text=keyword_text,
+            match_type=match_type,
+            bid=bid,
+            state=state,
+        )
+        return CreateKeywordResponse(**result)
+
+    @server.tool(
+        name="create_sp_product_ad",
+        description="Create a new Sponsored Products product ad. Seller accounts must pass sku; vendor accounts must pass asin.",
+    )
+    async def create_sp_product_ad_tool(
+        ctx: Context,
+        campaign_id: str,
+        ad_group_id: str,
+        asin: Optional[str] = None,
+        sku: Optional[str] = None,
+        state: str = "ENABLED",
+    ) -> CreateProductAdResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_product_ad(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            asin=asin,
+            sku=sku,
+            state=state,
+        )
+        return CreateProductAdResponse(**result)
+
+    @server.tool(
+        name="list_sp_campaigns",
+        description="List Sponsored Products campaigns, optionally filtered by name, state, or portfolio",
+    )
+    async def list_sp_campaigns_tool(
+        ctx: Context,
+        name_filter: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        portfolio_id_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListCampaignsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_campaigns(
+            name_filter=name_filter,
+            state_filter=state_filter,
+            portfolio_id_filter=portfolio_id_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListCampaignsResponse(**result)
+
+    @server.tool(
+        name="list_sp_product_ads",
+        description="List Sponsored Products product ads, optionally filtered by campaign/ad group and state",
+    )
+    async def list_sp_product_ads_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        ad_group_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListProductAdsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_product_ads(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListProductAdsResponse(**result)
+
+    # -----------------------------------------------------------------------
+    # Portfolios
+    # -----------------------------------------------------------------------
+
+    @server.tool(
+        name="list_sp_portfolios",
+        description="List Sponsored Products portfolios for the active profile, optionally filtered by name or portfolio ID",
+    )
+    async def list_sp_portfolios_tool(
+        ctx: Context,
+        name_filter: Optional[str] = None,
+        portfolio_id_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListPortfoliosResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_portfolios(
+            name_filter=name_filter,
+            portfolio_id_filter=portfolio_id_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListPortfoliosResponse(**result)
+
+    # -----------------------------------------------------------------------
+    # Campaign Negative Keywords
+    # -----------------------------------------------------------------------
+
+    @server.tool(
+        name="create_sp_negative_keyword",
+        description="Create a campaign-level negative keyword for Sponsored Products (match_type: NEGATIVE_EXACT or NEGATIVE_PHRASE)",
+    )
+    async def create_sp_negative_keyword_tool(
+        ctx: Context,
+        campaign_id: str,
+        keyword_text: str,
+        match_type: str,
+        state: str = "ENABLED",
+    ) -> CreateNegativeKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_negative_keyword(
+            campaign_id=campaign_id,
+            keyword_text=keyword_text,
+            match_type=match_type,
+            state=state,
+        )
+        return CreateNegativeKeywordResponse(**result)
+
+    @server.tool(
+        name="list_sp_negative_keywords",
+        description="List campaign-level Sponsored Products negative keywords, optionally filtered by campaign ID and state",
+    )
+    async def list_sp_negative_keywords_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListNegativeKeywordsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_negative_keywords(
+            campaign_id=campaign_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListNegativeKeywordsResponse(**result)
+
+    @server.tool(
+        name="update_sp_negative_keywords",
+        description="Update a campaign-level Sponsored Products negative keyword (state only: pause/enable/archive)",
+    )
+    async def update_sp_negative_keywords_tool(
+        ctx: Context,
+        keyword_id: str,
+        state: Optional[str] = None,
+    ) -> UpdateNegativeKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_negative_keywords(
+            keyword_id=keyword_id,
+            state=state,
+        )
+        return UpdateNegativeKeywordResponse(**result)
+
+    # -----------------------------------------------------------------------
+    # Targeting clauses (targets) — manual PT + auto targeting expressions
+    # -----------------------------------------------------------------------
+
+    @server.tool(
+        name="create_sp_target",
+        description="Create a Sponsored Products product target. Pass target_asin for ASIN targeting, or expression for full control (categories, refinements).",
+    )
+    async def create_sp_target_tool(
+        ctx: Context,
+        campaign_id: str,
+        ad_group_id: str,
+        bid: float,
+        target_asin: Optional[str] = None,
+        expression: Optional[List[Dict[str, str]]] = None,
+        expression_type: str = "MANUAL",
+        state: str = "ENABLED",
+    ) -> CreateTargetResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_target(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            bid=bid,
+            target_asin=target_asin,
+            expression=expression,
+            expression_type=expression_type,
+            state=state,
+        )
+        return CreateTargetResponse(**result)
+
+    @server.tool(
+        name="list_sp_targets",
+        description="List Sponsored Products targeting clauses. Works for both manual PT targets (ASIN/category) and auto-campaign targeting expressions (close-match/loose-match/substitutes/complements).",
+    )
+    async def list_sp_targets_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        ad_group_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListTargetsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_targets(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListTargetsResponse(**result)
+
+    @server.tool(
+        name="update_sp_targets",
+        description="Update a Sponsored Products target (change bid or state). Also works on auto-campaign targeting expressions.",
+    )
+    async def update_sp_targets_tool(
+        ctx: Context,
+        target_id: str,
+        bid: Optional[float] = None,
+        state: Optional[str] = None,
+    ) -> UpdateTargetResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_targets(
+            target_id=target_id,
+            bid=bid,
+            state=state,
+        )
+        return UpdateTargetResponse(**result)
+
+    # -----------------------------------------------------------------------
+    # Campaign Negative Targets (AUTO campaigns only)
+    # -----------------------------------------------------------------------
+
+    @server.tool(
+        name="create_sp_negative_target",
+        description="Create a campaign-level negative product target on an AUTO campaign. Pass negative_asin for ASIN blocking.",
+    )
+    async def create_sp_negative_target_tool(
+        ctx: Context,
+        campaign_id: str,
+        negative_asin: Optional[str] = None,
+        expression: Optional[List[Dict[str, str]]] = None,
+        state: str = "ENABLED",
+    ) -> CreateNegativeTargetResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_negative_target(
+            campaign_id=campaign_id,
+            negative_asin=negative_asin,
+            expression=expression,
+            state=state,
+        )
+        return CreateNegativeTargetResponse(**result)
+
+    @server.tool(
+        name="list_sp_negative_targets",
+        description="List campaign-level Sponsored Products negative targets",
+    )
+    async def list_sp_negative_targets_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListNegativeTargetsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_negative_targets(
+            campaign_id=campaign_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListNegativeTargetsResponse(**result)
+
+    @server.tool(
+        name="update_sp_negative_targets",
+        description="Update a campaign-level Sponsored Products negative target (state only: pause/enable/archive)",
+    )
+    async def update_sp_negative_targets_tool(
+        ctx: Context,
+        target_id: str,
+        state: Optional[str] = None,
+    ) -> UpdateNegativeTargetResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_negative_targets(
+            target_id=target_id,
+            state=state,
+        )
+        return UpdateNegativeTargetResponse(**result)
+
+    logger.info("Registered campaign management tools (23 tools)")
+
+
 async def register_oauth_tools_builtin(server: FastMCP):
     """Register OAuth authentication tools.
 
@@ -1478,6 +2037,7 @@ async def register_all_builtin_tools(
     # Routing tools removed - override functionality was redundant
     await register_download_tools(server)
     await register_report_catalog_tools(server)
+    await register_campaign_management_tools(server)
     await register_sampling_tools(server)
     # Cache & diagnostic tools removed - not core operations
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1345,7 +1345,10 @@ async def register_campaign_management_tools(server: FastMCP):
         name="update_sp_campaigns",
         description=(
             "Update a Sponsored Products campaign (rename, change budget, "
-            "pause/enable/archive, set placement bid adjustments, set bidding strategy). "
+            "pause/enable, set placement bid adjustments, set bidding strategy). "
+            "The SP v3 PUT /sp/campaigns endpoint only accepts state values "
+            "ENABLED or PAUSED — to archive a campaign, use archive_sp_campaign "
+            "(SP v3 routes archival through POST /sp/campaigns/delete). "
             "Placement adjustments (placement_top_pct, placement_product_page_pct, "
             "placement_rest_of_search_pct) are merged: omitted placements retain their "
             "current value. Each percentage must be 0-900."
@@ -1378,6 +1381,25 @@ async def register_campaign_management_tools(server: FastMCP):
             placement_product_page_pct=placement_product_page_pct,
             placement_rest_of_search_pct=placement_rest_of_search_pct,
             bidding_strategy=bidding_strategy,
+        )
+        return UpdateCampaignResponse(**result)
+
+    @server.tool(
+        name="archive_sp_campaign",
+        description=(
+            "Archive one Sponsored Products campaign permanently. "
+            "SP v3 splits state transitions (PUT /sp/campaigns — accepts only "
+            "ENABLED/PAUSED) from archival (POST /sp/campaigns/delete). "
+            "ARCHIVED is permanent and cannot be reversed through the API."
+        ),
+    )
+    async def archive_sp_campaign_tool(
+        ctx: Context,
+        campaign_id: str,
+    ) -> UpdateCampaignResponse:
+        _require_active_profile()
+        result = await campaign_management.archive_sp_campaign(
+            campaign_id=campaign_id,
         )
         return UpdateCampaignResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1514,7 +1514,13 @@ async def register_campaign_management_tools(server: FastMCP):
 
     @server.tool(
         name="update_sp_product_ads",
-        description="Update a Sponsored Products product ad state (pause/enable/archive)",
+        description=(
+            "Update a Sponsored Products product ad state (pause/enable). "
+            "The SP v3 PUT /sp/productAds endpoint only accepts state values "
+            "ENABLED or PAUSED — to archive a product ad, use "
+            "archive_sp_product_ad (SP v3 routes archival through "
+            "POST /sp/productAds/delete)."
+        ),
     )
     async def update_sp_product_ads_tool(
         ctx: Context,
@@ -1525,6 +1531,25 @@ async def register_campaign_management_tools(server: FastMCP):
         result = await campaign_management.update_sp_product_ads(
             ad_id=ad_id,
             state=state,
+        )
+        return UpdateProductAdResponse(**result)
+
+    @server.tool(
+        name="archive_sp_product_ad",
+        description=(
+            "Archive one Sponsored Products product ad permanently. "
+            "SP v3 splits state transitions (PUT /sp/productAds — accepts only "
+            "ENABLED/PAUSED) from archival (POST /sp/productAds/delete). "
+            "ARCHIVED is permanent and cannot be reversed through the API."
+        ),
+    )
+    async def archive_sp_product_ad_tool(
+        ctx: Context,
+        ad_id: str,
+    ) -> UpdateProductAdResponse:
+        _require_active_profile()
+        result = await campaign_management.archive_sp_product_ad(
+            ad_id=ad_id,
         )
         return UpdateProductAdResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1427,7 +1427,13 @@ async def register_campaign_management_tools(server: FastMCP):
 
     @server.tool(
         name="update_sp_ad_groups",
-        description="Update a Sponsored Products ad group (rename, change default bid, pause/enable/archive)",
+        description=(
+            "Update a Sponsored Products ad group (rename, change default bid, "
+            "pause/enable). The SP v3 PUT /sp/adGroups endpoint only accepts "
+            "state values ENABLED or PAUSED — to archive an ad group, use "
+            "archive_sp_ad_group (SP v3 routes archival through "
+            "POST /sp/adGroups/delete)."
+        ),
     )
     async def update_sp_ad_groups_tool(
         ctx: Context,
@@ -1442,6 +1448,25 @@ async def register_campaign_management_tools(server: FastMCP):
             name=name,
             state=state,
             default_bid=default_bid,
+        )
+        return UpdateAdGroupResponse(**result)
+
+    @server.tool(
+        name="archive_sp_ad_group",
+        description=(
+            "Archive one Sponsored Products ad group permanently. "
+            "SP v3 splits state transitions (PUT /sp/adGroups — accepts only "
+            "ENABLED/PAUSED) from archival (POST /sp/adGroups/delete). "
+            "ARCHIVED is permanent and cannot be reversed through the API."
+        ),
+    )
+    async def archive_sp_ad_group_tool(
+        ctx: Context,
+        ad_group_id: str,
+    ) -> UpdateAdGroupResponse:
+        _require_active_profile()
+        result = await campaign_management.archive_sp_ad_group(
+            ad_group_id=ad_group_id,
         )
         return UpdateAdGroupResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1946,7 +1946,13 @@ async def register_campaign_management_tools(server: FastMCP):
 
     @server.tool(
         name="update_sp_targets",
-        description="Update a Sponsored Products target (change bid or state). Also works on auto-campaign targeting expressions.",
+        description=(
+            "Update a Sponsored Products target (change bid or state). Also "
+            "works on auto-campaign targeting expressions. The SP v3 PUT "
+            "/sp/targets endpoint only accepts state values ENABLED or "
+            "PAUSED — to archive a target, use archive_sp_target (SP v3 "
+            "routes archival through POST /sp/targets/delete)."
+        ),
     )
     async def update_sp_targets_tool(
         ctx: Context,
@@ -1959,6 +1965,26 @@ async def register_campaign_management_tools(server: FastMCP):
             target_id=target_id,
             bid=bid,
             state=state,
+        )
+        return UpdateTargetResponse(**result)
+
+    @server.tool(
+        name="archive_sp_target",
+        description=(
+            "Archive one Sponsored Products target permanently. Also works "
+            "on auto-campaign targeting expressions. SP v3 splits state "
+            "transitions (PUT /sp/targets — accepts only ENABLED/PAUSED) "
+            "from archival (POST /sp/targets/delete). ARCHIVED is permanent "
+            "and cannot be reversed through the API."
+        ),
+    )
+    async def archive_sp_target_tool(
+        ctx: Context,
+        target_id: str,
+    ) -> UpdateTargetResponse:
+        _require_active_profile()
+        result = await campaign_management.archive_sp_target(
+            target_id=target_id,
         )
         return UpdateTargetResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1472,7 +1472,12 @@ async def register_campaign_management_tools(server: FastMCP):
 
     @server.tool(
         name="update_sp_keywords",
-        description="Update a Sponsored Products keyword (change bid, pause/enable/archive)",
+        description=(
+            "Update a Sponsored Products keyword (change bid, pause/enable). "
+            "The SP v3 PUT /sp/keywords endpoint only accepts state values "
+            "ENABLED or PAUSED — to archive a keyword, use archive_sp_keyword "
+            "(SP v3 routes archival through POST /sp/keywords/delete)."
+        ),
     )
     async def update_sp_keywords_tool(
         ctx: Context,
@@ -1485,6 +1490,25 @@ async def register_campaign_management_tools(server: FastMCP):
             keyword_id=keyword_id,
             state=state,
             bid=bid,
+        )
+        return UpdateKeywordResponse(**result)
+
+    @server.tool(
+        name="archive_sp_keyword",
+        description=(
+            "Archive one Sponsored Products keyword permanently. "
+            "SP v3 splits state transitions (PUT /sp/keywords — accepts only "
+            "ENABLED/PAUSED) from archival (POST /sp/keywords/delete). "
+            "ARCHIVED is permanent and cannot be reversed through the API."
+        ),
+    )
+    async def archive_sp_keyword_tool(
+        ctx: Context,
+        keyword_id: str,
+    ) -> UpdateKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.archive_sp_keyword(
+            keyword_id=keyword_id,
         )
         return UpdateKeywordResponse(**result)
 

--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -1733,6 +1733,70 @@ async def register_campaign_management_tools(server: FastMCP):
         return UpdateNegativeKeywordResponse(**result)
 
     # -----------------------------------------------------------------------
+    # Ad-group-level negative keywords (parallel to campaign-level above)
+    # -----------------------------------------------------------------------
+
+    @server.tool(
+        name="create_sp_ad_group_negative_keyword",
+        description="Create an ad-group-level negative keyword for Sponsored Products (match_type: NEGATIVE_EXACT or NEGATIVE_PHRASE)",
+    )
+    async def create_sp_ad_group_negative_keyword_tool(
+        ctx: Context,
+        campaign_id: str,
+        ad_group_id: str,
+        keyword_text: str,
+        match_type: str,
+        state: str = "ENABLED",
+    ) -> CreateNegativeKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.create_sp_ad_group_negative_keyword(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            keyword_text=keyword_text,
+            match_type=match_type,
+            state=state,
+        )
+        return CreateNegativeKeywordResponse(**result)
+
+    @server.tool(
+        name="list_sp_ad_group_negative_keywords",
+        description="List ad-group-level Sponsored Products negative keywords, optionally filtered by campaign ID, ad group ID, and state",
+    )
+    async def list_sp_ad_group_negative_keywords_tool(
+        ctx: Context,
+        campaign_id: Optional[str] = None,
+        ad_group_id: Optional[str] = None,
+        state_filter: Optional[str] = None,
+        max_results: int = 100,
+        next_token: Optional[str] = None,
+    ) -> ListNegativeKeywordsResponse:
+        _require_active_profile()
+        result = await campaign_management.list_sp_ad_group_negative_keywords(
+            campaign_id=campaign_id,
+            ad_group_id=ad_group_id,
+            state_filter=state_filter,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        return ListNegativeKeywordsResponse(**result)
+
+    @server.tool(
+        name="update_sp_ad_group_negative_keywords",
+        description="Update an ad-group-level Sponsored Products negative keyword (state only: pause/enable/archive)",
+    )
+    async def update_sp_ad_group_negative_keywords_tool(
+        ctx: Context,
+        keyword_id: str,
+        state: Optional[str] = None,
+    ) -> UpdateNegativeKeywordResponse:
+        _require_active_profile()
+        result = await campaign_management.update_sp_ad_group_negative_keywords(
+            keyword_id=keyword_id,
+            state=state,
+        )
+        return UpdateNegativeKeywordResponse(**result)
+
+    # -----------------------------------------------------------------------
     # Targeting clauses (targets) — manual PT + auto targeting expressions
     # -----------------------------------------------------------------------
 

--- a/src/amazon_ads_mcp/server/server_builder.py
+++ b/src/amazon_ads_mcp/server/server_builder.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     create_oauth_middleware = None
 from ..utils.header_resolver import HeaderNameResolver
-from ..utils.http_client import AuthenticatedClient
+from ..utils.http_client import AuthenticatedClient, set_authenticated_client
 from ..utils.media import MediaTypeRegistry
 from ..utils.region_config import RegionConfig
 from .openapi_utils import slim_openapi_for_tools
@@ -296,7 +296,7 @@ class ServerBuilder:
 
         import httpx
 
-        return AuthenticatedClient(
+        client = AuthenticatedClient(
             auth_manager=self.auth_manager,
             media_registry=self.media_registry,
             header_resolver=self.header_resolver,
@@ -309,6 +309,8 @@ class ServerBuilder:
                 pool=10.0,  # Pool timeout
             ),
         )
+        set_authenticated_client(client)
+        return client
 
     async def _register_sidecar_middleware(self) -> None:
         """Install the sidecar transform middleware.

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -965,7 +965,8 @@ async def list_sp_campaigns(
                 p.get("placement"): p.get("percentage")
                 for p in (dynamic.get("placementBidding") or [])
             }
-            extended = c.get("extendedData") or {}
+            extended_raw = c.get("extendedData")
+            extended = extended_raw or {}
             items.append({
                 "campaign_id": c.get("campaignId"),
                 "name": c.get("name"),
@@ -983,6 +984,9 @@ async def list_sp_campaigns(
                 "serving_status_details": extended.get("servingStatusDetails"),
                 "creation_date_time": extended.get("creationDateTime"),
                 "last_update_date_time": extended.get("lastUpdateDateTime"),
+                # Lossless passthrough: any extendedData field the API
+                # returns lives here, even ones not yet flattened above.
+                "extended_data": extended_raw,
             })
         return {
             "success": True,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -1,0 +1,1704 @@
+"""Campaign management tools for Amazon Ads MCP.
+
+Provides create, update, and list operations for Sponsored Products and
+Sponsored Brands campaigns, ad groups, keywords, product ads, targets,
+negative keywords, and negative targets.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _asin_expression(asin: str) -> List[Dict[str, str]]:
+    """Build a single-ASIN targeting expression (for create endpoints).
+
+    Note: v3 Sponsored Products endpoints — both list and create, for both
+    positive targets and negative targets — use UPPER_SNAKE_CASE enum
+    values (e.g. ASIN_SAME_AS). Never pass the camelCase form
+    (asinSameAs); the API rejects it with HTTP 400.
+    """
+    return [{"type": "ASIN_SAME_AS", "value": asin}]
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign updates
+# ---------------------------------------------------------------------------
+
+async def update_sp_campaigns(
+    campaign_id: str,
+    name: Optional[str] = None,
+    state: Optional[str] = None,
+    budget_amount: Optional[float] = None,
+    budget_type: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    placement_top_pct: Optional[int] = None,
+    placement_product_page_pct: Optional[int] = None,
+    placement_rest_of_search_pct: Optional[int] = None,
+    bidding_strategy: Optional[str] = None,
+) -> dict:
+    """Update one Sponsored Products campaign.
+
+    :param campaign_id: Campaign ID to update
+    :param name: New campaign name
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param budget_amount: New daily budget amount
+    :param budget_type: Budget type (DAILY)
+    :param start_date: Start date YYYYMMDD
+    :param end_date: End date YYYYMMDD
+    :param placement_top_pct: Top of Search placement bid adjustment (0-900)
+    :param placement_product_page_pct: Product Page placement bid adjustment (0-900)
+    :param placement_rest_of_search_pct: Rest of Search placement bid adjustment (0-900)
+    :param bidding_strategy: Bidding strategy (LEGACY_FOR_SALES, AUTO_FOR_SALES, MANUAL, RULE_BASED)
+
+    Placement adjustments are merged: any placement not specified retains its
+    current value, requiring a read-modify-write. The Amazon Ads v3 PUT
+    /sp/campaigns endpoint replaces the dynamicBidding object wholesale, so
+    omitting unchanged placements would silently zero them out.
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    bidding_fields_set = (
+        placement_top_pct is not None
+        or placement_product_page_pct is not None
+        or placement_rest_of_search_pct is not None
+        or bidding_strategy is not None
+    )
+
+    for label, value in (
+        ("placement_top_pct", placement_top_pct),
+        ("placement_product_page_pct", placement_product_page_pct),
+        ("placement_rest_of_search_pct", placement_rest_of_search_pct),
+    ):
+        if value is not None and (value < 0 or value > 900):
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": f"Invalid {label}: {value} (must be 0-900)",
+                "message": f"Invalid placement bidding value for {label}",
+            }
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spcampaign.v3+json",
+        "Content-Type": "application/vnd.spcampaign.v3+json",
+    }
+
+    current_placement: Dict[str, int] = {}
+    current_strategy: Optional[str] = None
+    if bidding_fields_set:
+        list_resp = await client.post(
+            "/sp/campaigns/list",
+            json={
+                "campaignIdFilter": {"include": [campaign_id]},
+                "maxResults": 1,
+            },
+            headers=headers,
+        )
+        if list_resp.status_code != 200:
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": f"HTTP {list_resp.status_code}: {list_resp.text[:300]}",
+                "message": "Pre-fetch for placement merge failed",
+            }
+        campaigns = list_resp.json().get("campaigns", [])
+        if not campaigns:
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": "Campaign not found",
+                "message": "Pre-fetch for placement merge returned no campaign",
+            }
+        dynamic = campaigns[0].get("dynamicBidding") or {}
+        current_strategy = dynamic.get("strategy")
+        for entry in dynamic.get("placementBidding") or []:
+            placement = entry.get("placement")
+            pct = entry.get("percentage")
+            if placement and pct is not None:
+                current_placement[placement] = int(pct)
+
+    campaign = {"campaignId": campaign_id}
+    if name is not None:
+        campaign["name"] = name
+    if state is not None:
+        campaign["state"] = state.upper()
+    if budget_amount is not None or budget_type is not None:
+        budget = {}
+        if budget_amount is not None:
+            budget["budget"] = budget_amount
+        if budget_type is not None:
+            budget["budgetType"] = budget_type.upper()
+        else:
+            budget["budgetType"] = "DAILY"
+        campaign["budget"] = budget
+    if start_date is not None:
+        campaign["startDate"] = start_date
+    if end_date is not None:
+        campaign["endDate"] = end_date
+
+    if bidding_fields_set:
+        dynamic_payload: Dict[str, Any] = {}
+        effective_strategy = (
+            bidding_strategy if bidding_strategy is not None else current_strategy
+        )
+        if effective_strategy:
+            dynamic_payload["strategy"] = effective_strategy.upper()
+
+        merged_placement = dict(current_placement)
+        if placement_top_pct is not None:
+            merged_placement["PLACEMENT_TOP"] = int(placement_top_pct)
+        if placement_product_page_pct is not None:
+            merged_placement["PLACEMENT_PRODUCT_PAGE"] = int(placement_product_page_pct)
+        if placement_rest_of_search_pct is not None:
+            merged_placement["PLACEMENT_REST_OF_SEARCH"] = int(placement_rest_of_search_pct)
+
+        if merged_placement:
+            dynamic_payload["placementBidding"] = [
+                {"placement": p, "percentage": v}
+                for p, v in sorted(merged_placement.items())
+            ]
+
+        if dynamic_payload:
+            campaign["dynamicBidding"] = dynamic_payload
+
+    resp = await client.put(
+        "/sp/campaigns",
+        json={"campaigns": [campaign]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaigns", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "campaign_id": campaign_id,
+                "message": f"Campaign {campaign_id} updated",
+                "updated_fields": {k: v for k, v in campaign.items() if k != "campaignId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to update campaign {campaign_id}",
+            }
+    return {
+        "success": False,
+        "campaign_id": campaign_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SB Campaign updates
+# ---------------------------------------------------------------------------
+
+async def update_sb_campaigns(
+    campaign_id: str,
+    name: Optional[str] = None,
+    state: Optional[str] = None,
+    budget_amount: Optional[float] = None,
+    budget_type: Optional[str] = None,
+) -> dict:
+    """Update one Sponsored Brands campaign.
+
+    :param campaign_id: Campaign ID to update
+    :param name: New campaign name
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param budget_amount: New budget amount
+    :param budget_type: Budget type (DAILY)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    campaign = {"campaignId": campaign_id}
+    if name is not None:
+        campaign["name"] = name
+    if state is not None:
+        campaign["state"] = state.upper()
+    if budget_amount is not None or budget_type is not None:
+        budget = {}
+        if budget_amount is not None:
+            budget["budget"] = budget_amount
+        if budget_type is not None:
+            budget["budgetType"] = budget_type.upper()
+        else:
+            budget["budgetType"] = "DAILY"
+        campaign["budget"] = budget
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.sbcampaignresource.v4+json",
+        "Content-Type": "application/vnd.sbcampaignresource.v4+json",
+    }
+    resp = await client.put(
+        "/sb/v4/campaigns",
+        json={"campaigns": [campaign]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaigns", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "campaign_id": campaign_id,
+                "message": f"SB campaign {campaign_id} updated",
+                "updated_fields": {k: v for k, v in campaign.items() if k != "campaignId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to update SB campaign {campaign_id}",
+            }
+    return {
+        "success": False,
+        "campaign_id": campaign_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Ad Group updates
+# ---------------------------------------------------------------------------
+
+async def update_sp_ad_groups(
+    ad_group_id: str,
+    name: Optional[str] = None,
+    state: Optional[str] = None,
+    default_bid: Optional[float] = None,
+) -> dict:
+    """Update one Sponsored Products ad group.
+
+    :param ad_group_id: Ad group ID to update
+    :param name: New ad group name
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param default_bid: New default bid amount
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    ad_group = {"adGroupId": ad_group_id}
+    if name is not None:
+        ad_group["name"] = name
+    if state is not None:
+        ad_group["state"] = state.upper()
+    if default_bid is not None:
+        ad_group["defaultBid"] = default_bid
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spAdGroup.v3+json",
+        "Content-Type": "application/vnd.spAdGroup.v3+json",
+    }
+    resp = await client.put(
+        "/sp/adGroups",
+        json={"adGroups": [ad_group]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("adGroups", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "ad_group_id": ad_group_id,
+                "message": f"Ad group {ad_group_id} updated",
+                "updated_fields": {k: v for k, v in ad_group.items() if k != "adGroupId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "ad_group_id": ad_group_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update ad group {ad_group_id}",
+            }
+    return {
+        "success": False,
+        "ad_group_id": ad_group_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Keyword updates
+# ---------------------------------------------------------------------------
+
+async def update_sp_keywords(
+    keyword_id: str,
+    state: Optional[str] = None,
+    bid: Optional[float] = None,
+) -> dict:
+    """Update one Sponsored Products keyword.
+
+    :param keyword_id: Keyword ID to update
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param bid: New bid amount
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    keyword = {"keywordId": keyword_id}
+    if state is not None:
+        keyword["state"] = state.upper()
+    if bid is not None:
+        keyword["bid"] = bid
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spKeyword.v3+json",
+        "Content-Type": "application/vnd.spKeyword.v3+json",
+    }
+    resp = await client.put(
+        "/sp/keywords",
+        json={"keywords": [keyword]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("keywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "keyword_id": keyword_id,
+                "message": f"Keyword {keyword_id} updated",
+                "updated_fields": {k: v for k, v in keyword.items() if k != "keywordId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": keyword_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update keyword {keyword_id}",
+            }
+    return {
+        "success": False,
+        "keyword_id": keyword_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Product Ad updates
+# ---------------------------------------------------------------------------
+
+async def update_sp_product_ads(
+    ad_id: str,
+    state: Optional[str] = None,
+) -> dict:
+    """Update one Sponsored Products product ad (state only).
+
+    :param ad_id: Product ad ID to update
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    ad = {"adId": ad_id}
+    if state is not None:
+        ad["state"] = state.upper()
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spProductAd.v3+json",
+        "Content-Type": "application/vnd.spProductAd.v3+json",
+    }
+    resp = await client.put(
+        "/sp/productAds",
+        json={"productAds": [ad]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("productAds", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "ad_id": ad_id,
+                "message": f"Product ad {ad_id} updated",
+                "updated_fields": {k: v for k, v in ad.items() if k != "adId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "ad_id": ad_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update product ad {ad_id}",
+            }
+    return {
+        "success": False,
+        "ad_id": ad_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Ad Group listing
+# ---------------------------------------------------------------------------
+
+async def list_sp_ad_groups(
+    campaign_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products ad groups with optional filters.
+
+    :param campaign_id: Filter by campaign ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spAdGroup.v3+json",
+        "Content-Type": "application/vnd.spAdGroup.v3+json",
+    }
+    resp = await client.post(
+        "/sp/adGroups/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        ad_groups = data.get("adGroups", [])
+        items = []
+        for ag in ad_groups:
+            items.append({
+                "ad_group_id": ag.get("adGroupId"),
+                "name": ag.get("name"),
+                "campaign_id": ag.get("campaignId"),
+                "state": ag.get("state"),
+                "default_bid": ag.get("defaultBid"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Keyword listing
+# ---------------------------------------------------------------------------
+
+async def list_sp_keywords(
+    campaign_id: Optional[str] = None,
+    ad_group_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products keywords with optional filters.
+
+    :param campaign_id: Filter by campaign ID
+    :param ad_group_id: Filter by ad group ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+    if ad_group_id:
+        body["adGroupIdFilter"] = {"include": [ad_group_id]}
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spKeyword.v3+json",
+        "Content-Type": "application/vnd.spKeyword.v3+json",
+    }
+    resp = await client.post(
+        "/sp/keywords/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        keywords = data.get("keywords", [])
+        items = []
+        for kw in keywords:
+            items.append({
+                "keyword_id": kw.get("keywordId"),
+                "keyword_text": kw.get("keywordText"),
+                "match_type": kw.get("matchType"),
+                "campaign_id": kw.get("campaignId"),
+                "ad_group_id": kw.get("adGroupId"),
+                "state": kw.get("state"),
+                "bid": kw.get("bid"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign creation
+# ---------------------------------------------------------------------------
+
+async def create_sp_campaign(
+    name: str,
+    targeting_type: str,
+    budget_amount: float,
+    state: str = "ENABLED",
+    portfolio_id: Optional[str] = None,
+    bidding_strategy: str = "LEGACY_FOR_SALES",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> dict:
+    """Create a new Sponsored Products campaign.
+
+    :param name: Campaign name
+    :param targeting_type: MANUAL or AUTO
+    :param budget_amount: Daily budget amount
+    :param state: Initial state (ENABLED, PAUSED)
+    :param portfolio_id: Portfolio ID to assign to
+    :param bidding_strategy: Bidding strategy (LEGACY_FOR_SALES = down only,
+        AUTO_FOR_SALES = up and down, MANUAL = fixed)
+    :param start_date: Start date YYYYMMDD (defaults to today)
+    :param end_date: End date YYYYMMDD
+    """
+    from datetime import datetime
+
+    from ..utils.http_client import get_authenticated_client
+
+    if start_date is None:
+        start_date = datetime.now().strftime("%Y%m%d")
+
+    campaign: dict = {
+        "name": name,
+        "targetingType": targeting_type.upper(),
+        "state": state.upper(),
+        "dynamicBidding": {"strategy": bidding_strategy},
+        "budget": {"budgetType": "DAILY", "budget": budget_amount},
+        "startDate": start_date,
+    }
+    if portfolio_id is not None:
+        campaign["portfolioId"] = portfolio_id
+    if end_date is not None:
+        campaign["endDate"] = end_date
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spcampaign.v3+json",
+        "Content-Type": "application/vnd.spcampaign.v3+json",
+    }
+    resp = await client.post(
+        "/sp/campaigns",
+        json={"campaigns": [campaign]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaigns", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            return {
+                "success": True,
+                "campaign_id": created.get("campaignId", created.get("campaign", {}).get("campaignId")),
+                "message": f"Campaign '{name}' created",
+                "details": created,
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "campaign_id": None,
+                "error": err.get("errors", err),
+                "message": f"Failed to create campaign '{name}'",
+            }
+    return {
+        "success": False,
+        "campaign_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Ad Group creation
+# ---------------------------------------------------------------------------
+
+async def create_sp_ad_group(
+    campaign_id: str,
+    name: str,
+    default_bid: float,
+    state: str = "ENABLED",
+) -> dict:
+    """Create a new Sponsored Products ad group.
+
+    :param campaign_id: Parent campaign ID
+    :param name: Ad group name
+    :param default_bid: Default bid amount
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    ad_group = {
+        "campaignId": campaign_id,
+        "name": name,
+        "state": state.upper(),
+        "defaultBid": default_bid,
+    }
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spAdGroup.v3+json",
+        "Content-Type": "application/vnd.spAdGroup.v3+json",
+    }
+    resp = await client.post(
+        "/sp/adGroups",
+        json={"adGroups": [ad_group]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("adGroups", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            return {
+                "success": True,
+                "ad_group_id": created.get("adGroupId", created.get("adGroup", {}).get("adGroupId")),
+                "message": f"Ad group '{name}' created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "ad_group_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to create ad group '{name}'",
+            }
+    return {
+        "success": False,
+        "ad_group_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Keyword creation
+# ---------------------------------------------------------------------------
+
+async def create_sp_keyword(
+    campaign_id: str,
+    ad_group_id: str,
+    keyword_text: str,
+    match_type: str,
+    bid: float,
+    state: str = "ENABLED",
+) -> dict:
+    """Create a new Sponsored Products keyword.
+
+    :param campaign_id: Parent campaign ID
+    :param ad_group_id: Parent ad group ID
+    :param keyword_text: The keyword text
+    :param match_type: EXACT, PHRASE, or BROAD
+    :param bid: Bid amount
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    keyword = {
+        "campaignId": campaign_id,
+        "adGroupId": ad_group_id,
+        "keywordText": keyword_text,
+        "matchType": match_type.upper(),
+        "bid": bid,
+        "state": state.upper(),
+    }
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spKeyword.v3+json",
+        "Content-Type": "application/vnd.spKeyword.v3+json",
+    }
+    resp = await client.post(
+        "/sp/keywords",
+        json={"keywords": [keyword]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("keywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            return {
+                "success": True,
+                "keyword_id": created.get("keywordId", created.get("keyword", {}).get("keywordId")),
+                "message": f"Keyword '{keyword_text}' created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to create keyword '{keyword_text}'",
+            }
+    return {
+        "success": False,
+        "keyword_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Product Ad creation
+# ---------------------------------------------------------------------------
+
+async def create_sp_product_ad(
+    campaign_id: str,
+    ad_group_id: str,
+    asin: Optional[str] = None,
+    sku: Optional[str] = None,
+    state: str = "ENABLED",
+) -> dict:
+    """Create a new Sponsored Products product ad.
+
+    Seller accounts must pass ``sku`` (Amazon requires merchantSku for
+    seller ads). Vendor accounts must pass ``asin``. At least one must
+    be provided.
+
+    :param campaign_id: Parent campaign ID
+    :param ad_group_id: Parent ad group ID
+    :param asin: Product ASIN (vendor accounts)
+    :param sku: Merchant SKU (seller accounts)
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    if asin is None and sku is None:
+        return {
+            "success": False,
+            "ad_id": None,
+            "error": "Must provide either asin (vendor) or sku (seller)",
+            "message": "Missing product identifier",
+        }
+
+    product_ad: Dict[str, Any] = {
+        "campaignId": campaign_id,
+        "adGroupId": ad_group_id,
+        "state": state.upper(),
+    }
+    if asin is not None:
+        product_ad["asin"] = asin
+    if sku is not None:
+        product_ad["sku"] = sku
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spProductAd.v3+json",
+        "Content-Type": "application/vnd.spProductAd.v3+json",
+    }
+    resp = await client.post(
+        "/sp/productAds",
+        json={"productAds": [product_ad]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("productAds", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            ident = sku or asin
+            return {
+                "success": True,
+                "ad_id": created.get("adId", created.get("productAd", {}).get("adId")),
+                "message": f"Product ad for {ident} created",
+                "details": created,
+            }
+        elif error_list:
+            ident = sku or asin
+            return {
+                "success": False,
+                "ad_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to create product ad for {ident}",
+            }
+    return {
+        "success": False,
+        "ad_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign listing
+# ---------------------------------------------------------------------------
+
+async def list_sp_campaigns(
+    name_filter: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    portfolio_id_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products campaigns with optional filters.
+
+    :param name_filter: Filter by campaign name (contains match)
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param portfolio_id_filter: Filter by portfolio ID
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if name_filter:
+        body["nameFilter"] = {"queryTermMatchType": "BROAD_MATCH", "include": [name_filter]}
+    if portfolio_id_filter:
+        body["portfolioIdFilter"] = {"include": [portfolio_id_filter]}
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spcampaign.v3+json",
+        "Content-Type": "application/vnd.spcampaign.v3+json",
+    }
+    resp = await client.post(
+        "/sp/campaigns/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        campaigns = data.get("campaigns", [])
+        items = []
+        for c in campaigns:
+            budget = c.get("budget", {})
+            dynamic = c.get("dynamicBidding", {}) or {}
+            placement_map = {
+                p.get("placement"): p.get("percentage")
+                for p in (dynamic.get("placementBidding") or [])
+            }
+            items.append({
+                "campaign_id": c.get("campaignId"),
+                "name": c.get("name"),
+                "state": c.get("state"),
+                "targeting_type": c.get("targetingType"),
+                "budget_amount": budget.get("budget"),
+                "budget_type": budget.get("budgetType"),
+                "portfolio_id": c.get("portfolioId"),
+                "start_date": c.get("startDate"),
+                "bidding_strategy": dynamic.get("strategy"),
+                "placement_top_pct": placement_map.get("PLACEMENT_TOP", 0),
+                "placement_product_page_pct": placement_map.get("PLACEMENT_PRODUCT_PAGE", 0),
+                "placement_rest_of_search_pct": placement_map.get("PLACEMENT_REST_OF_SEARCH", 0),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Product Ad listing
+# ---------------------------------------------------------------------------
+
+async def list_sp_product_ads(
+    campaign_id: Optional[str] = None,
+    ad_group_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products product ads with optional filters.
+
+    :param campaign_id: Filter by campaign ID
+    :param ad_group_id: Filter by ad group ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+    if ad_group_id:
+        body["adGroupIdFilter"] = {"include": [ad_group_id]}
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spProductAd.v3+json",
+        "Content-Type": "application/vnd.spProductAd.v3+json",
+    }
+    resp = await client.post(
+        "/sp/productAds/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        ads = data.get("productAds", [])
+        items = []
+        for ad in ads:
+            items.append({
+                "ad_id": ad.get("adId"),
+                "campaign_id": ad.get("campaignId"),
+                "ad_group_id": ad.get("adGroupId"),
+                "asin": ad.get("asin"),
+                "state": ad.get("state"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Portfolio listing (for resolving portfolio names -> IDs)
+# ---------------------------------------------------------------------------
+
+_PORTFOLIO_CT = "application/vnd.spportfolio.v1+json"
+
+
+async def list_sp_portfolios(
+    name_filter: Optional[str] = None,
+    portfolio_id_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products portfolios for the active profile.
+
+    :param name_filter: Filter by portfolio name (BROAD match)
+    :param portfolio_id_filter: Filter by specific portfolio ID
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if name_filter:
+        body["nameFilter"] = {
+            "queryTermMatchType": "BROAD_MATCH",
+            "include": [name_filter],
+        }
+    if portfolio_id_filter:
+        body["portfolioIdFilter"] = {"include": [portfolio_id_filter]}
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _PORTFOLIO_CT, "Content-Type": _PORTFOLIO_CT}
+    resp = await client.post(
+        "/portfolios/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        portfolios = data.get("portfolios", [])
+        items = []
+        for p in portfolios:
+            items.append({
+                "portfolio_id": p.get("portfolioId"),
+                "name": p.get("name"),
+                "state": p.get("state"),
+                "in_budget": p.get("inBudget"),
+                "budget_policy": p.get("budget", {}).get("policy"),
+                "budget_currency": p.get("budget", {}).get("currencyCode"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "total_results": data.get("totalResults"),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign Negative Keywords (create / list / update)
+# ---------------------------------------------------------------------------
+
+_NEG_KW_CT = "application/vnd.spCampaignNegativeKeyword.v3+json"
+
+
+async def create_sp_negative_keyword(
+    campaign_id: str,
+    keyword_text: str,
+    match_type: str,
+    state: str = "ENABLED",
+) -> dict:
+    """Create a campaign-level negative keyword for Sponsored Products.
+
+    :param campaign_id: Parent campaign ID
+    :param keyword_text: The keyword text to negate
+    :param match_type: NEGATIVE_EXACT or NEGATIVE_PHRASE
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    neg_kw = {
+        "campaignId": campaign_id,
+        "keywordText": keyword_text,
+        "matchType": match_type.upper(),
+        "state": state.upper(),
+    }
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_KW_CT, "Content-Type": _NEG_KW_CT}
+    resp = await client.post(
+        "/sp/campaignNegativeKeywords",
+        json={"campaignNegativeKeywords": [neg_kw]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaignNegativeKeywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            kwid = created.get("keywordId") or created.get(
+                "campaignNegativeKeyword", {}
+            ).get("keywordId")
+            return {
+                "success": True,
+                "keyword_id": kwid,
+                "message": f"Negative keyword '{keyword_text}' created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to create negative keyword '{keyword_text}'",
+            }
+    return {
+        "success": False,
+        "keyword_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def list_sp_negative_keywords(
+    campaign_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List campaign-level negative keywords with optional filters.
+
+    :param campaign_id: Filter by campaign ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_KW_CT, "Content-Type": _NEG_KW_CT}
+    resp = await client.post(
+        "/sp/campaignNegativeKeywords/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        items_raw = data.get("campaignNegativeKeywords", [])
+        items = []
+        for kw in items_raw:
+            items.append({
+                "keyword_id": kw.get("keywordId"),
+                "keyword_text": kw.get("keywordText"),
+                "match_type": kw.get("matchType"),
+                "campaign_id": kw.get("campaignId"),
+                "state": kw.get("state"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+async def update_sp_negative_keywords(
+    keyword_id: str,
+    state: Optional[str] = None,
+) -> dict:
+    """Update a campaign-level negative keyword (state only).
+
+    :param keyword_id: Negative keyword ID
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    neg_kw = {"keywordId": keyword_id}
+    if state is not None:
+        neg_kw["state"] = state.upper()
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_KW_CT, "Content-Type": _NEG_KW_CT}
+    resp = await client.put(
+        "/sp/campaignNegativeKeywords",
+        json={"campaignNegativeKeywords": [neg_kw]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaignNegativeKeywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "keyword_id": keyword_id,
+                "message": f"Negative keyword {keyword_id} updated",
+                "updated_fields": {k: v for k, v in neg_kw.items() if k != "keywordId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": keyword_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update negative keyword {keyword_id}",
+            }
+    return {
+        "success": False,
+        "keyword_id": keyword_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Targets (product targeting — create / list / update)
+# ---------------------------------------------------------------------------
+
+_TARGET_CT = "application/vnd.spTargetingClause.v3+json"
+
+
+async def create_sp_target(
+    campaign_id: str,
+    ad_group_id: str,
+    bid: float,
+    target_asin: Optional[str] = None,
+    expression: Optional[List[Dict[str, str]]] = None,
+    expression_type: str = "MANUAL",
+    state: str = "ENABLED",
+) -> dict:
+    """Create a product target in a manual SP campaign.
+
+    Provide either `target_asin` (shortcut for ASIN-same-as targeting) OR
+    `expression` (full predicate list, e.g. category targets).
+
+    :param campaign_id: Parent campaign ID
+    :param ad_group_id: Parent ad group ID
+    :param bid: Bid amount
+    :param target_asin: Shortcut — target a specific ASIN (ASIN_SAME_AS)
+    :param expression: Full expression predicate list
+        (e.g. [{"type": "ASIN_SAME_AS", "value": "B0..."}])
+    :param expression_type: MANUAL (default) or AUTO
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    if expression is None and target_asin is None:
+        return {
+            "success": False,
+            "target_id": None,
+            "error": "Must provide either target_asin or expression",
+            "message": "Missing targeting expression",
+        }
+    if expression is None:
+        expression = _asin_expression(target_asin)
+
+    clause: Dict[str, Any] = {
+        "campaignId": campaign_id,
+        "adGroupId": ad_group_id,
+        "expression": expression,
+        "expressionType": expression_type.upper(),
+        "bid": bid,
+        "state": state.upper(),
+    }
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _TARGET_CT, "Content-Type": _TARGET_CT}
+    resp = await client.post(
+        "/sp/targets",
+        json={"targetingClauses": [clause]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("targetingClauses", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            tid = created.get("targetId") or created.get(
+                "targetingClause", {}
+            ).get("targetId")
+            return {
+                "success": True,
+                "target_id": tid,
+                "message": "Target created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "target_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": "Failed to create target",
+            }
+    return {
+        "success": False,
+        "target_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def list_sp_targets(
+    campaign_id: Optional[str] = None,
+    ad_group_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List Sponsored Products targeting clauses (targets).
+
+    Returns both manual PT targets and auto-campaign targeting expressions
+    (close-match, loose-match, substitutes, complements).
+
+    :param campaign_id: Filter by campaign ID
+    :param ad_group_id: Filter by ad group ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+    if ad_group_id:
+        body["adGroupIdFilter"] = {"include": [ad_group_id]}
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _TARGET_CT, "Content-Type": _TARGET_CT}
+    resp = await client.post(
+        "/sp/targets/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        clauses = data.get("targetingClauses", [])
+        items = []
+        for c in clauses:
+            items.append({
+                "target_id": c.get("targetId"),
+                "campaign_id": c.get("campaignId"),
+                "ad_group_id": c.get("adGroupId"),
+                "expression": c.get("expression"),
+                "resolved_expression": c.get("resolvedExpression"),
+                "expression_type": c.get("expressionType"),
+                "state": c.get("state"),
+                "bid": c.get("bid"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+async def update_sp_targets(
+    target_id: str,
+    bid: Optional[float] = None,
+    state: Optional[str] = None,
+) -> dict:
+    """Update a Sponsored Products target (change bid or state).
+
+    Also updates auto-campaign targeting expressions (close-match, loose-match,
+    substitutes, complements) since those share the same /sp/targets endpoint.
+
+    :param target_id: Target ID (also called targetingClause ID)
+    :param bid: New bid amount
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    clause: Dict[str, Any] = {"targetId": target_id}
+    if bid is not None:
+        clause["bid"] = bid
+    if state is not None:
+        clause["state"] = state.upper()
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _TARGET_CT, "Content-Type": _TARGET_CT}
+    resp = await client.put(
+        "/sp/targets",
+        json={"targetingClauses": [clause]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("targetingClauses", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "target_id": target_id,
+                "message": f"Target {target_id} updated",
+                "updated_fields": {k: v for k, v in clause.items() if k != "targetId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "target_id": target_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update target {target_id}",
+            }
+    return {
+        "success": False,
+        "target_id": target_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign Negative Targets (create / list / update)
+# ---------------------------------------------------------------------------
+
+_NEG_TGT_CT = "application/vnd.spCampaignNegativeTargetingClause.v3+json"
+
+
+async def create_sp_negative_target(
+    campaign_id: str,
+    negative_asin: Optional[str] = None,
+    expression: Optional[List[Dict[str, str]]] = None,
+    state: str = "ENABLED",
+) -> dict:
+    """Create a campaign-level negative product target.
+
+    Available only for AUTO campaigns (per Amazon Ads API). Provide either
+    `negative_asin` or `expression`.
+
+    :param campaign_id: Parent campaign ID (must be AUTO)
+    :param negative_asin: Shortcut — block a specific ASIN (ASIN_SAME_AS)
+    :param expression: Full expression predicate list
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    if expression is None and negative_asin is None:
+        return {
+            "success": False,
+            "target_id": None,
+            "error": "Must provide either negative_asin or expression",
+            "message": "Missing negative targeting expression",
+        }
+    if expression is None:
+        expression = _asin_expression(negative_asin)
+
+    clause: Dict[str, Any] = {
+        "campaignId": campaign_id,
+        "expression": expression,
+        "state": state.upper(),
+    }
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_TGT_CT, "Content-Type": _NEG_TGT_CT}
+    resp = await client.post(
+        "/sp/campaignNegativeTargets",
+        json={"campaignNegativeTargetingClauses": [clause]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaignNegativeTargetingClauses", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            tid = created.get("targetId") or created.get(
+                "campaignNegativeTargetingClause", {}
+            ).get("targetId")
+            return {
+                "success": True,
+                "target_id": tid,
+                "message": "Negative target created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "target_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": "Failed to create negative target",
+            }
+    return {
+        "success": False,
+        "target_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def list_sp_negative_targets(
+    campaign_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List campaign-level negative targets.
+
+    :param campaign_id: Filter by campaign ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_TGT_CT, "Content-Type": _NEG_TGT_CT}
+    resp = await client.post(
+        "/sp/campaignNegativeTargets/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        clauses = data.get("campaignNegativeTargetingClauses", [])
+        items = []
+        for c in clauses:
+            items.append({
+                "target_id": c.get("targetId"),
+                "campaign_id": c.get("campaignId"),
+                "expression": c.get("expression"),
+                "resolved_expression": c.get("resolvedExpression"),
+                "state": c.get("state"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+async def update_sp_negative_targets(
+    target_id: str,
+    state: Optional[str] = None,
+) -> dict:
+    """Update a campaign-level negative target (state only).
+
+    :param target_id: Negative target ID
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    clause: Dict[str, Any] = {"targetId": target_id}
+    if state is not None:
+        clause["state"] = state.upper()
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _NEG_TGT_CT, "Content-Type": _NEG_TGT_CT}
+    resp = await client.put(
+        "/sp/campaignNegativeTargets",
+        json={"campaignNegativeTargetingClauses": [clause]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaignNegativeTargetingClauses", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "target_id": target_id,
+                "message": f"Negative target {target_id} updated",
+                "updated_fields": {k: v for k, v in clause.items() if k != "targetId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "target_id": target_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update negative target {target_id}",
+            }
+    return {
+        "success": False,
+        "target_id": target_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -913,6 +913,7 @@ async def list_sp_campaigns(
     portfolio_id_filter: Optional[str] = None,
     max_results: int = 100,
     next_token: Optional[str] = None,
+    include_extended_data: bool = False,
 ) -> dict:
     """List Sponsored Products campaigns with optional filters.
 
@@ -921,6 +922,11 @@ async def list_sp_campaigns(
     :param portfolio_id_filter: Filter by portfolio ID
     :param max_results: Max results per page (default 100)
     :param next_token: Pagination token from previous response
+    :param include_extended_data: Request extendedData fields. Surfaces
+        servingStatus (delivery health — CAMPAIGN_OUT_OF_BUDGET, etc.),
+        servingStatusDetails (human-readable reasons), creationDateTime,
+        and lastUpdateDateTime on each item. Slightly slower upstream; off
+        by default.
     """
     from ..utils.http_client import get_authenticated_client
 
@@ -934,6 +940,8 @@ async def list_sp_campaigns(
         body["nameFilter"] = {"queryTermMatchType": "BROAD_MATCH", "include": [name_filter]}
     if portfolio_id_filter:
         body["portfolioIdFilter"] = {"include": [portfolio_id_filter]}
+    if include_extended_data:
+        body["includeExtendedDataFields"] = True
 
     client = await get_authenticated_client()
     headers = {
@@ -957,6 +965,7 @@ async def list_sp_campaigns(
                 p.get("placement"): p.get("percentage")
                 for p in (dynamic.get("placementBidding") or [])
             }
+            extended = c.get("extendedData") or {}
             items.append({
                 "campaign_id": c.get("campaignId"),
                 "name": c.get("name"),
@@ -970,6 +979,10 @@ async def list_sp_campaigns(
                 "placement_top_pct": placement_map.get("PLACEMENT_TOP", 0),
                 "placement_product_page_pct": placement_map.get("PLACEMENT_PRODUCT_PAGE", 0),
                 "placement_rest_of_search_pct": placement_map.get("PLACEMENT_REST_OF_SEARCH", 0),
+                "serving_status": extended.get("servingStatus"),
+                "serving_status_details": extended.get("servingStatusDetails"),
+                "creation_date_time": extended.get("creationDateTime"),
+                "last_update_date_time": extended.get("lastUpdateDateTime"),
             })
         return {
             "success": True,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -43,7 +43,8 @@ async def update_sp_campaigns(
 
     :param campaign_id: Campaign ID to update
     :param name: New campaign name
-    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param state: New state (ENABLED, PAUSED). The SP v3 PUT /sp/campaigns
+        endpoint rejects ARCHIVED — use archive_sp_campaign instead.
     :param budget_amount: New daily budget amount
     :param budget_type: Budget type (DAILY)
     :param start_date: Start date YYYYMMDD
@@ -190,6 +191,62 @@ async def update_sp_campaigns(
                 "campaign_id": campaign_id,
                 "error": err.get("errors", err),
                 "message": f"Failed to update campaign {campaign_id}",
+            }
+    return {
+        "success": False,
+        "campaign_id": campaign_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SP Campaign archive
+# ---------------------------------------------------------------------------
+
+async def archive_sp_campaign(campaign_id: str) -> dict:
+    """Archive one Sponsored Products campaign.
+
+    SP v3 splits state transitions (PUT /sp/campaigns — accepts only
+    ENABLED/PAUSED) from archival (POST /sp/campaigns/delete). The 'delete'
+    endpoint is misnamed: it archives. ARCHIVED is permanent and cannot be
+    reversed through the API.
+
+    :param campaign_id: Campaign ID to archive
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spcampaign.v3+json",
+        "Content-Type": "application/vnd.spcampaign.v3+json",
+    }
+    resp = await client.post(
+        "/sp/campaigns/delete",
+        json={"campaignIdFilter": {"include": [campaign_id]}},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("campaigns", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "campaign_id": campaign_id,
+                "message": f"Campaign {campaign_id} archived",
+                "updated_fields": {"state": "ARCHIVED"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "campaign_id": campaign_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to archive campaign {campaign_id}",
             }
     return {
         "success": False,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -1899,9 +1899,13 @@ async def update_sp_targets(
     Also updates auto-campaign targeting expressions (close-match, loose-match,
     substitutes, complements) since those share the same /sp/targets endpoint.
 
+    The SP v3 PUT /sp/targets endpoint only accepts state values ENABLED
+    or PAUSED — to archive a target, use archive_sp_target, which routes
+    through POST /sp/targets/delete.
+
     :param target_id: Target ID (also called targetingClause ID)
     :param bid: New bid amount
-    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param state: New state (ENABLED, PAUSED)
     """
     from ..utils.http_client import get_authenticated_client
 
@@ -1938,6 +1942,60 @@ async def update_sp_targets(
                 "target_id": target_id,
                 "error": error_list[0].get("errors", error_list[0]),
                 "message": f"Failed to update target {target_id}",
+            }
+    return {
+        "success": False,
+        "target_id": target_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def archive_sp_target(target_id: str) -> dict:
+    """Archive one Sponsored Products target (targeting clause).
+
+    Also archives auto-campaign targeting expressions (close-match,
+    loose-match, substitutes, complements) since those share the same
+    /sp/targets endpoint family.
+
+    SP v3 splits state transitions (PUT /sp/targets — accepts only
+    ENABLED/PAUSED) from archival (POST /sp/targets/delete). The 'delete'
+    endpoint is misnamed: it archives. ARCHIVED is permanent and cannot be
+    reversed through the API. The response key is `targetingClauses` (not
+    `targets`), matching the PUT response shape.
+
+    :param target_id: Target ID (also called targetingClause ID)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _TARGET_CT, "Content-Type": _TARGET_CT}
+    resp = await client.post(
+        "/sp/targets/delete",
+        json={"targetIdFilter": {"include": [target_id]}},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("targetingClauses", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "target_id": target_id,
+                "message": f"Target {target_id} archived",
+                "updated_fields": {"state": "ARCHIVED"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "target_id": target_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to archive target {target_id}",
             }
     return {
         "success": False,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -344,9 +344,13 @@ async def update_sp_ad_groups(
 ) -> dict:
     """Update one Sponsored Products ad group.
 
+    The SP v3 PUT /sp/adGroups endpoint only accepts state values ENABLED
+    or PAUSED — to archive an ad group, use archive_sp_ad_group, which
+    routes through POST /sp/adGroups/delete.
+
     :param ad_group_id: Ad group ID to update
     :param name: New ad group name
-    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param state: New state (ENABLED, PAUSED)
     :param default_bid: New default bid amount
     """
     from ..utils.http_client import get_authenticated_client
@@ -389,6 +393,58 @@ async def update_sp_ad_groups(
                 "ad_group_id": ad_group_id,
                 "error": error_list[0].get("errors", error_list[0]),
                 "message": f"Failed to update ad group {ad_group_id}",
+            }
+    return {
+        "success": False,
+        "ad_group_id": ad_group_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def archive_sp_ad_group(ad_group_id: str) -> dict:
+    """Archive one Sponsored Products ad group.
+
+    SP v3 splits state transitions (PUT /sp/adGroups — accepts only
+    ENABLED/PAUSED) from archival (POST /sp/adGroups/delete). The 'delete'
+    endpoint is misnamed: it archives. ARCHIVED is permanent and cannot be
+    reversed through the API.
+
+    :param ad_group_id: Ad group ID to archive
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spAdGroup.v3+json",
+        "Content-Type": "application/vnd.spAdGroup.v3+json",
+    }
+    resp = await client.post(
+        "/sp/adGroups/delete",
+        json={"adGroupIdFilter": {"include": [ad_group_id]}},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("adGroups", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "ad_group_id": ad_group_id,
+                "message": f"Ad group {ad_group_id} archived",
+                "updated_fields": {"state": "ARCHIVED"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "ad_group_id": ad_group_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to archive ad group {ad_group_id}",
             }
     return {
         "success": False,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -1317,6 +1317,194 @@ async def update_sp_negative_keywords(
 
 
 # ---------------------------------------------------------------------------
+# SP Ad Group Negative Keywords (create / list / update)
+# ---------------------------------------------------------------------------
+# SP v3 distinguishes campaign-scope and ad-group-scope negative keywords by
+# endpoint family. Ad-group scope uses /sp/negativeKeywords with
+# application/vnd.spNegativeKeyword.v3+json. Campaign scope (above) uses
+# /sp/campaignNegativeKeywords with vnd.spCampaignNegativeKeyword.v3+json.
+
+_AG_NEG_KW_CT = "application/vnd.spNegativeKeyword.v3+json"
+
+
+async def create_sp_ad_group_negative_keyword(
+    campaign_id: str,
+    ad_group_id: str,
+    keyword_text: str,
+    match_type: str,
+    state: str = "ENABLED",
+) -> dict:
+    """Create an ad-group-level negative keyword for Sponsored Products.
+
+    :param campaign_id: Parent campaign ID
+    :param ad_group_id: Parent ad group ID
+    :param keyword_text: The keyword text to negate
+    :param match_type: NEGATIVE_EXACT or NEGATIVE_PHRASE
+    :param state: Initial state (ENABLED, PAUSED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    neg_kw = {
+        "campaignId": campaign_id,
+        "adGroupId": ad_group_id,
+        "keywordText": keyword_text,
+        "matchType": match_type.upper(),
+        "state": state.upper(),
+    }
+    client = await get_authenticated_client()
+    headers = {"Accept": _AG_NEG_KW_CT, "Content-Type": _AG_NEG_KW_CT}
+    resp = await client.post(
+        "/sp/negativeKeywords",
+        json={"negativeKeywords": [neg_kw]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("negativeKeywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            created = success_list[0]
+            kwid = created.get("keywordId") or created.get(
+                "negativeKeyword", {}
+            ).get("keywordId")
+            return {
+                "success": True,
+                "keyword_id": kwid,
+                "message": f"Ad-group negative keyword '{keyword_text}' created",
+                "details": created,
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": None,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to create ad-group negative keyword '{keyword_text}'",
+            }
+    return {
+        "success": False,
+        "keyword_id": None,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def list_sp_ad_group_negative_keywords(
+    campaign_id: Optional[str] = None,
+    ad_group_id: Optional[str] = None,
+    state_filter: Optional[str] = None,
+    max_results: int = 100,
+    next_token: Optional[str] = None,
+) -> dict:
+    """List ad-group-level negative keywords with optional filters.
+
+    :param campaign_id: Filter by campaign ID
+    :param ad_group_id: Filter by ad group ID
+    :param state_filter: Comma-separated states (ENABLED,PAUSED,ARCHIVED)
+    :param max_results: Max results per page (default 100)
+    :param next_token: Pagination token from previous response
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    body: dict = {"maxResults": max_results}
+    if next_token:
+        body["nextToken"] = next_token
+    if state_filter:
+        states = [s.strip().upper() for s in state_filter.split(",")]
+        body["stateFilter"] = {"include": states}
+    if campaign_id:
+        body["campaignIdFilter"] = {"include": [campaign_id]}
+    if ad_group_id:
+        body["adGroupIdFilter"] = {"include": [ad_group_id]}
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _AG_NEG_KW_CT, "Content-Type": _AG_NEG_KW_CT}
+    resp = await client.post(
+        "/sp/negativeKeywords/list",
+        json=body,
+        headers=headers,
+    )
+
+    if resp.status_code == 200:
+        data = resp.json()
+        items_raw = data.get("negativeKeywords", [])
+        items = []
+        for kw in items_raw:
+            items.append({
+                "keyword_id": kw.get("keywordId"),
+                "keyword_text": kw.get("keywordText"),
+                "match_type": kw.get("matchType"),
+                "campaign_id": kw.get("campaignId"),
+                "ad_group_id": kw.get("adGroupId"),
+                "state": kw.get("state"),
+            })
+        return {
+            "success": True,
+            "items": items,
+            "count": len(items),
+            "next_token": data.get("nextToken"),
+        }
+    return {
+        "success": False,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "items": [],
+        "count": 0,
+    }
+
+
+async def update_sp_ad_group_negative_keywords(
+    keyword_id: str,
+    state: Optional[str] = None,
+) -> dict:
+    """Update an ad-group-level negative keyword (state only).
+
+    :param keyword_id: Negative keyword ID
+    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    neg_kw: dict = {"keywordId": keyword_id}
+    if state is not None:
+        neg_kw["state"] = state.upper()
+
+    client = await get_authenticated_client()
+    headers = {"Accept": _AG_NEG_KW_CT, "Content-Type": _AG_NEG_KW_CT}
+    resp = await client.put(
+        "/sp/negativeKeywords",
+        json={"negativeKeywords": [neg_kw]},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("negativeKeywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "keyword_id": keyword_id,
+                "message": f"Ad-group negative keyword {keyword_id} updated",
+                "updated_fields": {k: v for k, v in neg_kw.items() if k != "keywordId"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            return {
+                "success": False,
+                "keyword_id": keyword_id,
+                "error": error_list[0].get("errors", error_list[0]),
+                "message": f"Failed to update ad-group negative keyword {keyword_id}",
+            }
+    return {
+        "success": False,
+        "keyword_id": keyword_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+# ---------------------------------------------------------------------------
 # SP Targets (product targeting — create / list / update)
 # ---------------------------------------------------------------------------
 

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -582,8 +582,12 @@ async def update_sp_product_ads(
 ) -> dict:
     """Update one Sponsored Products product ad (state only).
 
+    The SP v3 PUT /sp/productAds endpoint only accepts state values
+    ENABLED or PAUSED — to archive a product ad, use archive_sp_product_ad,
+    which routes through POST /sp/productAds/delete.
+
     :param ad_id: Product ad ID to update
-    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param state: New state (ENABLED, PAUSED)
     """
     from ..utils.http_client import get_authenticated_client
 
@@ -621,6 +625,60 @@ async def update_sp_product_ads(
                 "ad_id": ad_id,
                 "error": error_list[0].get("errors", error_list[0]),
                 "message": f"Failed to update product ad {ad_id}",
+            }
+    return {
+        "success": False,
+        "ad_id": ad_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def archive_sp_product_ad(ad_id: str) -> dict:
+    """Archive one Sponsored Products product ad.
+
+    SP v3 splits state transitions (PUT /sp/productAds — accepts only
+    ENABLED/PAUSED) from archival (POST /sp/productAds/delete). The
+    'delete' endpoint is misnamed: it archives. ARCHIVED is permanent and
+    cannot be reversed through the API. The filter key is `adIdFilter`
+    (not `productAdIdFilter`) because the ID field on a product ad is
+    `adId`.
+
+    :param ad_id: Product ad ID to archive
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spProductAd.v3+json",
+        "Content-Type": "application/vnd.spProductAd.v3+json",
+    }
+    resp = await client.post(
+        "/sp/productAds/delete",
+        json={"adIdFilter": {"include": [ad_id]}},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("productAds", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "ad_id": ad_id,
+                "message": f"Product ad {ad_id} archived",
+                "updated_fields": {"state": "ARCHIVED"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "ad_id": ad_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to archive product ad {ad_id}",
             }
     return {
         "success": False,

--- a/src/amazon_ads_mcp/tools/campaign_management.py
+++ b/src/amazon_ads_mcp/tools/campaign_management.py
@@ -465,8 +465,12 @@ async def update_sp_keywords(
 ) -> dict:
     """Update one Sponsored Products keyword.
 
+    The SP v3 PUT /sp/keywords endpoint only accepts state values ENABLED
+    or PAUSED — to archive a keyword, use archive_sp_keyword, which
+    routes through POST /sp/keywords/delete.
+
     :param keyword_id: Keyword ID to update
-    :param state: New state (ENABLED, PAUSED, ARCHIVED)
+    :param state: New state (ENABLED, PAUSED)
     :param bid: New bid amount
     """
     from ..utils.http_client import get_authenticated_client
@@ -507,6 +511,58 @@ async def update_sp_keywords(
                 "keyword_id": keyword_id,
                 "error": error_list[0].get("errors", error_list[0]),
                 "message": f"Failed to update keyword {keyword_id}",
+            }
+    return {
+        "success": False,
+        "keyword_id": keyword_id,
+        "error": f"HTTP {resp.status_code}: {resp.text[:500]}",
+        "message": "API request failed",
+    }
+
+
+async def archive_sp_keyword(keyword_id: str) -> dict:
+    """Archive one Sponsored Products keyword.
+
+    SP v3 splits state transitions (PUT /sp/keywords — accepts only
+    ENABLED/PAUSED) from archival (POST /sp/keywords/delete). The 'delete'
+    endpoint is misnamed: it archives. ARCHIVED is permanent and cannot be
+    reversed through the API.
+
+    :param keyword_id: Keyword ID to archive
+    """
+    from ..utils.http_client import get_authenticated_client
+
+    client = await get_authenticated_client()
+    headers = {
+        "Accept": "application/vnd.spKeyword.v3+json",
+        "Content-Type": "application/vnd.spKeyword.v3+json",
+    }
+    resp = await client.post(
+        "/sp/keywords/delete",
+        json={"keywordIdFilter": {"include": [keyword_id]}},
+        headers=headers,
+    )
+
+    if resp.status_code in (200, 207):
+        data = resp.json()
+        results = data.get("keywords", {})
+        success_list = results.get("success", [])
+        error_list = results.get("error", [])
+        if success_list:
+            return {
+                "success": True,
+                "keyword_id": keyword_id,
+                "message": f"Keyword {keyword_id} archived",
+                "updated_fields": {"state": "ARCHIVED"},
+                "details": success_list[0],
+            }
+        elif error_list:
+            err = error_list[0]
+            return {
+                "success": False,
+                "keyword_id": keyword_id,
+                "error": err.get("errors", err),
+                "message": f"Failed to archive keyword {keyword_id}",
             }
     return {
         "success": False,

--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -62,6 +62,57 @@ async def get_authenticated_client() -> "AuthenticatedClient":
     return _authenticated_client
 
 
+async def bootstrap_standalone_client() -> "AuthenticatedClient":
+    """Create and register an AuthenticatedClient outside the MCP server flow.
+
+    Mirrors the minimum subset of ``ServerBuilder._setup_http_client`` so
+    standalone CLI scripts (e.g. the negation-batch runner) can reach
+    Amazon Ads API without booting the full MCP server. Idempotent:
+    returns the existing singleton if one has already been registered.
+
+    :return: The registered AuthenticatedClient instance
+    :rtype: AuthenticatedClient
+    """
+    global _authenticated_client
+    if _authenticated_client is not None:
+        return _authenticated_client
+
+    from ..auth.manager import get_auth_manager
+    from ..config.settings import settings
+    from .header_resolver import HeaderNameResolver
+    from .media import MediaTypeRegistry
+    from .region_config import RegionConfig
+
+    auth_mgr = get_auth_manager()
+
+    # Match ServerBuilder._setup_default_identity: activate the configured
+    # default identity so AuthManager.get_headers() resolves at call time.
+    default_id = getattr(auth_mgr, "_default_identity_id", None)
+    if default_id:
+        try:
+            await auth_mgr.set_active_identity(default_id)
+        except Exception as e:
+            logger.warning(
+                "Standalone bootstrap: default identity activation failed: %s", e
+            )
+
+    region = settings.amazon_ads_region
+    provider = getattr(auth_mgr, "provider", None)
+    if provider is not None and getattr(provider, "provider_type", None) == "openbridge":
+        region = "na"
+    base_url = RegionConfig.get_api_endpoint(region)
+
+    client = AuthenticatedClient(
+        auth_manager=auth_mgr,
+        media_registry=MediaTypeRegistry(),
+        header_resolver=HeaderNameResolver(),
+        base_url=base_url,
+        timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0),
+    )
+    set_authenticated_client(client)
+    return client
+
+
 # Context-local routing overrides/state to avoid cross-request leakage
 _REGION_OVERRIDE_VAR: ContextVar[Optional[str]] = ContextVar(
     "amazon_ads_region_override", default=None

--- a/src/amazon_ads_mcp/utils/sp_enum_normalize.py
+++ b/src/amazon_ads_mcp/utils/sp_enum_normalize.py
@@ -1,0 +1,49 @@
+"""SP v3 expression-type normalization helpers (response-side parsing).
+
+Added 2026-05-05 after a weekly Marketing MCP run hit 9 false NOT FOUNDs because
+execute scripts compared SP v3 expression types in camelCase. SP v3 actually
+returns uppercase snake_case (ASIN_SAME_AS, QUERY_HIGH_REL_MATCHES, ...).
+"""
+from __future__ import annotations
+
+SP_V3_EXPRESSION_TYPES: tuple[str, ...] = (
+    "ASIN_SAME_AS",
+    "QUERY_HIGH_REL_MATCHES",
+    "QUERY_BROAD_REL_MATCHES",
+    "ASIN_ACCESSORY_RELATED",
+    "ASIN_SUBSTITUTE_RELATED",
+)
+
+
+def _key(value: str) -> str:
+    return value.upper().replace("_", "")
+
+
+_CANONICAL_BY_KEY: dict[str, str] = {_key(t): t for t in SP_V3_EXPRESSION_TYPES}
+
+
+def normalize_expression_type(value: str) -> str:
+    """Return the canonical SCREAMING_SNAKE_CASE form of an SP v3 expression type.
+
+    Accepts the canonical form (ASIN_SAME_AS) or the camelCase alias the docs
+    sometimes show (asinSameAs); both collapse to the canonical form. Raises
+    KeyError if the value is not a known SP v3 expression type.
+    """
+    if not isinstance(value, str):
+        raise KeyError(value)
+    canonical = _CANONICAL_BY_KEY.get(_key(value))
+    if canonical is None:
+        raise KeyError(value)
+    return canonical
+
+
+def is_expression_type(value: str, target: str) -> bool:
+    """Case- and separator-insensitive comparison for SP v3 expression types.
+
+    Returns True when `value` and `target` refer to the same SP v3 expression
+    type — accepting either canonical SCREAMING_SNAKE_CASE or camelCase on
+    either side. Returns False on any non-string input.
+    """
+    if not isinstance(value, str) or not isinstance(target, str):
+        return False
+    return _key(value) == _key(target)

--- a/tests/unit/test_archive_sp_ad_group.py
+++ b/tests/unit/test_archive_sp_ad_group.py
@@ -1,0 +1,93 @@
+"""Tests for archive_sp_ad_group.
+
+SP v3 splits ad-group archival from state transitions: PUT /sp/adGroups
+only accepts ENABLED/PAUSED (ARCHIVED → HTTP 400), and archival is
+routed through POST /sp/adGroups/delete with body
+``{"adGroupIdFilter": {"include": [<id>]}}``. Response is 207 with the
+same `adGroups.success` / `adGroups.error` shape as PUT.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _patch_client(monkeypatch, resp: _FakeResponse) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_archive_success_207(monkeypatch):
+    client = _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {"adGroups": {"success": [{"index": 0, "adGroupId": "AG1"}], "error": []}},
+        ),
+    )
+
+    result = await campaign_management.archive_sp_ad_group(ad_group_id="AG1")
+
+    assert result["success"] is True
+    assert result["ad_group_id"] == "AG1"
+    assert result["updated_fields"] == {"state": "ARCHIVED"}
+    # Body shape: adGroupIdFilter wraps the include list.
+    call = client.post.call_args
+    assert call.args[0] == "/sp/adGroups/delete"
+    assert call.kwargs["json"] == {"adGroupIdFilter": {"include": ["AG1"]}}
+
+
+@pytest.mark.asyncio
+async def test_archive_error_list_207(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "adGroups": {
+                    "success": [],
+                    "error": [
+                        {"index": 0, "errors": [{"errorType": "INVALID_ARGUMENT"}]}
+                    ],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_ad_group(ad_group_id="AG_BAD")
+
+    assert result["success"] is False
+    assert result["ad_group_id"] == "AG_BAD"
+    assert result["error"] == [{"errorType": "INVALID_ARGUMENT"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_non_2xx(monkeypatch):
+    _patch_client(monkeypatch, _FakeResponse(500, {}, text="upstream timeout"))
+
+    result = await campaign_management.archive_sp_ad_group(ad_group_id="AG2")
+
+    assert result["success"] is False
+    assert result["ad_group_id"] == "AG2"
+    assert "HTTP 500" in result["error"]
+    assert "upstream timeout" in result["error"]

--- a/tests/unit/test_archive_sp_campaign.py
+++ b/tests/unit/test_archive_sp_campaign.py
@@ -1,0 +1,97 @@
+"""Tests for archive_sp_campaign.
+
+Retroactive parity coverage for the v3 archive-endpoint trap fix
+originally shipped in cac7889. SP v3 splits campaign archival from
+state transitions: PUT /sp/campaigns only accepts ENABLED/PAUSED
+(ARCHIVED → HTTP 400), and archival is routed through
+POST /sp/campaigns/delete with body
+``{"campaignIdFilter": {"include": [<id>]}}``. Response is 207 with
+the same `campaigns.success` / `campaigns.error` shape as PUT.
+
+Matches the test contract of the four sibling archive_sp_* tools added
+in 218ec19, 9d2e9e9, dcb8139, 28dd860.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _patch_client(monkeypatch, resp: _FakeResponse) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_archive_success_207(monkeypatch):
+    client = _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {"campaigns": {"success": [{"index": 0, "campaignId": "C1"}], "error": []}},
+        ),
+    )
+
+    result = await campaign_management.archive_sp_campaign(campaign_id="C1")
+
+    assert result["success"] is True
+    assert result["campaign_id"] == "C1"
+    assert result["updated_fields"] == {"state": "ARCHIVED"}
+    call = client.post.call_args
+    assert call.args[0] == "/sp/campaigns/delete"
+    assert call.kwargs["json"] == {"campaignIdFilter": {"include": ["C1"]}}
+
+
+@pytest.mark.asyncio
+async def test_archive_error_list_207(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "campaigns": {
+                    "success": [],
+                    "error": [
+                        {"index": 0, "errors": [{"errorType": "INVALID_ARGUMENT"}]}
+                    ],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_campaign(campaign_id="C_BAD")
+
+    assert result["success"] is False
+    assert result["campaign_id"] == "C_BAD"
+    assert result["error"] == [{"errorType": "INVALID_ARGUMENT"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_non_2xx(monkeypatch):
+    _patch_client(monkeypatch, _FakeResponse(500, {}, text="upstream timeout"))
+
+    result = await campaign_management.archive_sp_campaign(campaign_id="C2")
+
+    assert result["success"] is False
+    assert result["campaign_id"] == "C2"
+    assert "HTTP 500" in result["error"]
+    assert "upstream timeout" in result["error"]

--- a/tests/unit/test_archive_sp_keyword.py
+++ b/tests/unit/test_archive_sp_keyword.py
@@ -1,0 +1,92 @@
+"""Tests for archive_sp_keyword.
+
+SP v3 splits keyword archival from state transitions: PUT /sp/keywords
+only accepts ENABLED/PAUSED (ARCHIVED → HTTP 400), and archival is
+routed through POST /sp/keywords/delete with body
+``{"keywordIdFilter": {"include": [<id>]}}``. Response is 207 with the
+same `keywords.success` / `keywords.error` shape as PUT.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _patch_client(monkeypatch, resp: _FakeResponse) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_archive_success_207(monkeypatch):
+    client = _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {"keywords": {"success": [{"index": 0, "keywordId": "K1"}], "error": []}},
+        ),
+    )
+
+    result = await campaign_management.archive_sp_keyword(keyword_id="K1")
+
+    assert result["success"] is True
+    assert result["keyword_id"] == "K1"
+    assert result["updated_fields"] == {"state": "ARCHIVED"}
+    call = client.post.call_args
+    assert call.args[0] == "/sp/keywords/delete"
+    assert call.kwargs["json"] == {"keywordIdFilter": {"include": ["K1"]}}
+
+
+@pytest.mark.asyncio
+async def test_archive_error_list_207(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "keywords": {
+                    "success": [],
+                    "error": [
+                        {"index": 0, "errors": [{"errorType": "INVALID_ARGUMENT"}]}
+                    ],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_keyword(keyword_id="K_BAD")
+
+    assert result["success"] is False
+    assert result["keyword_id"] == "K_BAD"
+    assert result["error"] == [{"errorType": "INVALID_ARGUMENT"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_non_2xx(monkeypatch):
+    _patch_client(monkeypatch, _FakeResponse(500, {}, text="upstream timeout"))
+
+    result = await campaign_management.archive_sp_keyword(keyword_id="K2")
+
+    assert result["success"] is False
+    assert result["keyword_id"] == "K2"
+    assert "HTTP 500" in result["error"]
+    assert "upstream timeout" in result["error"]

--- a/tests/unit/test_archive_sp_product_ad.py
+++ b/tests/unit/test_archive_sp_product_ad.py
@@ -1,0 +1,94 @@
+"""Tests for archive_sp_product_ad.
+
+SP v3 splits product-ad archival from state transitions: PUT /sp/productAds
+only accepts ENABLED/PAUSED (ARCHIVED → HTTP 400), and archival is
+routed through POST /sp/productAds/delete. The filter key is
+``adIdFilter`` (NOT ``productAdIdFilter``) because the ID field on a
+product ad is ``adId``. Response is 207 with `productAds.success` /
+`productAds.error` arrays.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _patch_client(monkeypatch, resp: _FakeResponse) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_archive_success_207(monkeypatch):
+    client = _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {"productAds": {"success": [{"index": 0, "adId": "AD1"}], "error": []}},
+        ),
+    )
+
+    result = await campaign_management.archive_sp_product_ad(ad_id="AD1")
+
+    assert result["success"] is True
+    assert result["ad_id"] == "AD1"
+    assert result["updated_fields"] == {"state": "ARCHIVED"}
+    # Body shape uses adIdFilter, NOT productAdIdFilter.
+    call = client.post.call_args
+    assert call.args[0] == "/sp/productAds/delete"
+    assert call.kwargs["json"] == {"adIdFilter": {"include": ["AD1"]}}
+
+
+@pytest.mark.asyncio
+async def test_archive_error_list_207(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "productAds": {
+                    "success": [],
+                    "error": [
+                        {"index": 0, "errors": [{"errorType": "INVALID_ARGUMENT"}]}
+                    ],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_product_ad(ad_id="AD_BAD")
+
+    assert result["success"] is False
+    assert result["ad_id"] == "AD_BAD"
+    assert result["error"] == [{"errorType": "INVALID_ARGUMENT"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_non_2xx(monkeypatch):
+    _patch_client(monkeypatch, _FakeResponse(500, {}, text="upstream timeout"))
+
+    result = await campaign_management.archive_sp_product_ad(ad_id="AD2")
+
+    assert result["success"] is False
+    assert result["ad_id"] == "AD2"
+    assert "HTTP 500" in result["error"]
+    assert "upstream timeout" in result["error"]

--- a/tests/unit/test_archive_sp_target.py
+++ b/tests/unit/test_archive_sp_target.py
@@ -1,0 +1,98 @@
+"""Tests for archive_sp_target.
+
+SP v3 splits target archival from state transitions: PUT /sp/targets
+only accepts ENABLED/PAUSED (ARCHIVED → HTTP 400), and archival is
+routed through POST /sp/targets/delete with body
+``{"targetIdFilter": {"include": [<id>]}}``. Response key is
+``targetingClauses`` (NOT ``targets``), matching the PUT response
+shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _patch_client(monkeypatch, resp: _FakeResponse) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_archive_success_207(monkeypatch):
+    client = _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "targetingClauses": {
+                    "success": [{"index": 0, "targetId": "T1"}],
+                    "error": [],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_target(target_id="T1")
+
+    assert result["success"] is True
+    assert result["target_id"] == "T1"
+    assert result["updated_fields"] == {"state": "ARCHIVED"}
+    call = client.post.call_args
+    assert call.args[0] == "/sp/targets/delete"
+    assert call.kwargs["json"] == {"targetIdFilter": {"include": ["T1"]}}
+
+
+@pytest.mark.asyncio
+async def test_archive_error_list_207(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _FakeResponse(
+            207,
+            {
+                "targetingClauses": {
+                    "success": [],
+                    "error": [
+                        {"index": 0, "errors": [{"errorType": "INVALID_ARGUMENT"}]}
+                    ],
+                }
+            },
+        ),
+    )
+
+    result = await campaign_management.archive_sp_target(target_id="T_BAD")
+
+    assert result["success"] is False
+    assert result["target_id"] == "T_BAD"
+    assert result["error"] == [{"errorType": "INVALID_ARGUMENT"}]
+
+
+@pytest.mark.asyncio
+async def test_archive_non_2xx(monkeypatch):
+    _patch_client(monkeypatch, _FakeResponse(500, {}, text="upstream timeout"))
+
+    result = await campaign_management.archive_sp_target(target_id="T2")
+
+    assert result["success"] is False
+    assert result["target_id"] == "T2"
+    assert "HTTP 500" in result["error"]
+    assert "upstream timeout" in result["error"]

--- a/tests/unit/test_list_sp_campaigns_extended_data.py
+++ b/tests/unit/test_list_sp_campaigns_extended_data.py
@@ -1,0 +1,118 @@
+"""Tests for include_extended_data on list_sp_campaigns.
+
+Surfaces serving_status (the OOB delivery-health signal) plus the extended
+metadata fields the Amazon Ads SP v3 endpoint returns when
+includeExtendedDataFields is set on the request.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _bind_client(monkeypatch, client):
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+
+@pytest.mark.asyncio
+async def test_extended_data_flag_passed_to_api(monkeypatch):
+    payload = {"campaigns": []}
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, payload))
+    _bind_client(monkeypatch, client)
+
+    await campaign_management.list_sp_campaigns(include_extended_data=True)
+
+    sent_body = client.post.call_args.kwargs["json"]
+    assert sent_body.get("includeExtendedDataFields") is True
+
+
+@pytest.mark.asyncio
+async def test_extended_data_flag_omitted_by_default(monkeypatch):
+    payload = {"campaigns": []}
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, payload))
+    _bind_client(monkeypatch, client)
+
+    await campaign_management.list_sp_campaigns()
+
+    sent_body = client.post.call_args.kwargs["json"]
+    assert "includeExtendedDataFields" not in sent_body
+
+
+@pytest.mark.asyncio
+async def test_serving_status_surfaced_on_items(monkeypatch):
+    payload = {
+        "campaigns": [
+            {
+                "campaignId": "C1",
+                "name": "Test Campaign",
+                "state": "ENABLED",
+                "extendedData": {
+                    "servingStatus": "CAMPAIGN_OUT_OF_BUDGET",
+                    "servingStatusDetails": [
+                        {
+                            "name": "CAMPAIGN_OUT_OF_BUDGET",
+                            "message": "Campaign daily budget reached.",
+                            "helpUrl": "https://advertising.amazon.com/help",
+                        }
+                    ],
+                    "creationDateTime": "2024-04-08T10:00:00Z",
+                    "lastUpdateDateTime": "2026-04-28T18:30:00Z",
+                },
+            }
+        ]
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, payload))
+    _bind_client(monkeypatch, client)
+
+    result = await campaign_management.list_sp_campaigns(include_extended_data=True)
+
+    assert result["success"] is True
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["serving_status"] == "CAMPAIGN_OUT_OF_BUDGET"
+    assert item["serving_status_details"][0]["name"] == "CAMPAIGN_OUT_OF_BUDGET"
+    assert item["creation_date_time"] == "2024-04-08T10:00:00Z"
+    assert item["last_update_date_time"] == "2026-04-28T18:30:00Z"
+
+
+@pytest.mark.asyncio
+async def test_no_extended_data_yields_none_for_extended_fields(monkeypatch):
+    payload = {
+        "campaigns": [
+            {"campaignId": "C2", "name": "Plain", "state": "ENABLED"}
+        ]
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, payload))
+    _bind_client(monkeypatch, client)
+
+    result = await campaign_management.list_sp_campaigns()
+
+    item = result["items"][0]
+    assert item["serving_status"] is None
+    assert item["serving_status_details"] is None
+    assert item["creation_date_time"] is None
+    assert item["last_update_date_time"] is None
+    # Pre-existing fields still present
+    assert item["campaign_id"] == "C2"
+    assert item["state"] == "ENABLED"

--- a/tests/unit/test_list_sp_campaigns_extended_data.py
+++ b/tests/unit/test_list_sp_campaigns_extended_data.py
@@ -113,6 +113,43 @@ async def test_no_extended_data_yields_none_for_extended_fields(monkeypatch):
     assert item["serving_status_details"] is None
     assert item["creation_date_time"] is None
     assert item["last_update_date_time"] is None
+    assert item["extended_data"] is None
     # Pre-existing fields still present
     assert item["campaign_id"] == "C2"
     assert item["state"] == "ENABLED"
+
+
+@pytest.mark.asyncio
+async def test_extended_data_passthrough_preserves_unknown_fields(monkeypatch):
+    """Future-proofing: any field the API adds under extendedData must
+    survive in the extended_data passthrough, not get silently dropped."""
+    payload = {
+        "campaigns": [
+            {
+                "campaignId": "C3",
+                "name": "Future-fields Campaign",
+                "state": "ENABLED",
+                "extendedData": {
+                    "servingStatus": "CAMPAIGN_STATUS_ENABLED",
+                    "creationDateTime": "2024-04-08T10:00:00Z",
+                    # Hypothetical new field Amazon could add tomorrow
+                    "deliveryHealthScore": 0.92,
+                    "lastBidEvaluationDateTime": "2026-04-28T22:00:00Z",
+                },
+            }
+        ]
+    }
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, payload))
+    _bind_client(monkeypatch, client)
+
+    result = await campaign_management.list_sp_campaigns(include_extended_data=True)
+
+    item = result["items"][0]
+    # Flattened convenience keys still populate
+    assert item["serving_status"] == "CAMPAIGN_STATUS_ENABLED"
+    assert item["creation_date_time"] == "2024-04-08T10:00:00Z"
+    # Full passthrough preserves everything, including unknown fields
+    assert item["extended_data"]["deliveryHealthScore"] == 0.92
+    assert item["extended_data"]["lastBidEvaluationDateTime"] == "2026-04-28T22:00:00Z"
+    assert item["extended_data"]["servingStatus"] == "CAMPAIGN_STATUS_ENABLED"

--- a/tests/unit/test_update_sp_campaigns_placement.py
+++ b/tests/unit/test_update_sp_campaigns_placement.py
@@ -1,0 +1,162 @@
+"""Tests for placement bid adjustment merge in update_sp_campaigns.
+
+Covers the read-modify-write contract: any placement not specified in the
+update call must retain its current value, since the v3 PUT endpoint
+replaces the dynamicBidding object wholesale.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amazon_ads_mcp.tools import campaign_management
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _build_client(list_payload: dict, put_payload: dict) -> MagicMock:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_FakeResponse(200, list_payload))
+    client.put = AsyncMock(return_value=_FakeResponse(200, put_payload))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_placement_update_merges_existing_values(monkeypatch):
+    list_payload = {
+        "campaigns": [
+            {
+                "campaignId": "C1",
+                "dynamicBidding": {
+                    "strategy": "LEGACY_FOR_SALES",
+                    "placementBidding": [
+                        {"placement": "PLACEMENT_TOP", "percentage": 10},
+                        {"placement": "PLACEMENT_PRODUCT_PAGE", "percentage": 15},
+                        {"placement": "PLACEMENT_REST_OF_SEARCH", "percentage": 5},
+                    ],
+                },
+            }
+        ]
+    }
+    put_payload = {"campaigns": {"success": [{"index": 0, "campaignId": "C1"}], "error": []}}
+    client = _build_client(list_payload, put_payload)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await campaign_management.update_sp_campaigns(
+        campaign_id="C1", placement_top_pct=25
+    )
+
+    assert result["success"] is True
+    put_body = client.put.call_args.kwargs["json"]
+    sent = put_body["campaigns"][0]["dynamicBidding"]
+    sent_map = {p["placement"]: p["percentage"] for p in sent["placementBidding"]}
+    assert sent_map == {
+        "PLACEMENT_TOP": 25,
+        "PLACEMENT_PRODUCT_PAGE": 15,
+        "PLACEMENT_REST_OF_SEARCH": 5,
+    }
+    assert sent["strategy"] == "LEGACY_FOR_SALES"
+
+
+@pytest.mark.asyncio
+async def test_strategy_only_update_preserves_existing_placement(monkeypatch):
+    list_payload = {
+        "campaigns": [
+            {
+                "campaignId": "C2",
+                "dynamicBidding": {
+                    "strategy": "LEGACY_FOR_SALES",
+                    "placementBidding": [
+                        {"placement": "PLACEMENT_TOP", "percentage": 10},
+                    ],
+                },
+            }
+        ]
+    }
+    put_payload = {"campaigns": {"success": [{"index": 0, "campaignId": "C2"}], "error": []}}
+    client = _build_client(list_payload, put_payload)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await campaign_management.update_sp_campaigns(
+        campaign_id="C2", bidding_strategy="MANUAL"
+    )
+
+    assert result["success"] is True
+    sent = client.put.call_args.kwargs["json"]["campaigns"][0]["dynamicBidding"]
+    assert sent["strategy"] == "MANUAL"
+    assert sent["placementBidding"] == [{"placement": "PLACEMENT_TOP", "percentage": 10}]
+
+
+@pytest.mark.asyncio
+async def test_no_bidding_fields_skips_prefetch(monkeypatch):
+    put_payload = {"campaigns": {"success": [{"index": 0, "campaignId": "C3"}], "error": []}}
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=AssertionError("post should not be called"))
+    client.put = AsyncMock(return_value=_FakeResponse(200, put_payload))
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await campaign_management.update_sp_campaigns(
+        campaign_id="C3", name="renamed"
+    )
+
+    assert result["success"] is True
+    sent = client.put.call_args.kwargs["json"]["campaigns"][0]
+    assert "dynamicBidding" not in sent
+    assert sent["name"] == "renamed"
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_placement_rejected(monkeypatch):
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=AssertionError("should fail before any HTTP call"))
+    client.put = AsyncMock(side_effect=AssertionError("should fail before any HTTP call"))
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await campaign_management.update_sp_campaigns(
+        campaign_id="C4", placement_top_pct=901
+    )
+
+    assert result["success"] is False
+    assert "0-900" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_empty_dynamic_bidding_creates_fresh_placement(monkeypatch):
+    list_payload = {"campaigns": [{"campaignId": "C5", "dynamicBidding": None}]}
+    put_payload = {"campaigns": {"success": [{"index": 0, "campaignId": "C5"}], "error": []}}
+    client = _build_client(list_payload, put_payload)
+    monkeypatch.setattr(
+        "amazon_ads_mcp.utils.http_client.get_authenticated_client",
+        AsyncMock(return_value=client),
+    )
+
+    result = await campaign_management.update_sp_campaigns(
+        campaign_id="C5", placement_top_pct=20
+    )
+
+    assert result["success"] is True
+    sent = client.put.call_args.kwargs["json"]["campaigns"][0]["dynamicBidding"]
+    assert sent["placementBidding"] == [{"placement": "PLACEMENT_TOP", "percentage": 20}]
+    assert "strategy" not in sent

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 
 [[package]]
 name = "amazon-ads-mcp"
-version = "0.3.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Adds the campaign-management write-tool surface to the MCP server and closes the SP v3 archive-endpoint trap across all five SP entity types (campaigns, ad groups, keywords, product ads, targets).

## Scope

This PR has grown beyond the original `archive_sp_campaign` scope. Three layers:

1. **Campaign-management write tools** — placement bid adjustments, batch hardening, ad-group-level negative keywords, NOTE-TOKENS doc, expression-type normalization (commits `b31ca4d`, `31daa95`, `480abec`, `2b506a2`, `c600718`, `a0dcf86`).
2. **SP v3 archive endpoint — campaigns** — adds `archive_sp_campaign` to wrap `POST /sp/campaigns/delete`, since `PUT /sp/campaigns` only accepts `ENABLED/PAUSED` (commit `cac7889`).
3. **SP v3 archive endpoint — siblings** — same trap exists on `PUT /sp/adGroups`, `PUT /sp/keywords`, `PUT /sp/productAds`, `PUT /sp/targets`; adds matching archive tools (commits `218ec19`, `9d2e9e9`, `86af93a`, `530b798`, `201e03f`).

## The archive trap

Every SP v3 entity update endpoint accepts only `ENABLED/PAUSED/PROPOSED` in the `state` field — `ARCHIVED` returns `HTTP 400 INVALID_ARGUMENT`. SP v3 routes archival through a separate `POST /sp/<entity>/delete` endpoint (misnamed — it archives, doesn't hard-delete). Verified against `dist/openapi/resources/SponsoredProducts.json`:

| Update tool (PUT) | State enum | Archive tool (POST `/delete`) | Filter key | Response key |
|---|---|---|---|---|
| `update_sp_campaigns` | `[ENABLED, PAUSED, PROPOSED]` | `archive_sp_campaign` | `campaignIdFilter` | `campaigns` |
| `update_sp_ad_groups` | `[ENABLED, PAUSED, PROPOSED]` | `archive_sp_ad_group` | `adGroupIdFilter` | `adGroups` |
| `update_sp_keywords` | `[ENABLED, PAUSED, PROPOSED]` | `archive_sp_keyword` | `keywordIdFilter` | `keywords` |
| `update_sp_product_ads` | `[ENABLED, PAUSED, PROPOSED]` | `archive_sp_product_ad` | **`adIdFilter`** (not `productAdIdFilter`) | `productAds` |
| `update_sp_targets` | `[ENABLED, PAUSED, PROPOSED]` | `archive_sp_target` | `targetIdFilter` | **`targetingClauses`** (not `targets`) |

Two filter/response-key wrinkles caught during the audit and pinned by test assertions:
- `productAds/delete` uses `adIdFilter` because the ID field on a product ad is `adId`.
- `targets/delete` returns `targetingClauses` (matching the PUT response shape on `/sp/targets`).

Each `update_sp_*` tool description and docstring no longer claims ARCHIVED support; each points callers at the corresponding `archive_sp_*` tool.

## Tests

Each `archive_sp_*` tool ships with three unit tests at parity (commit `201e03f` backfills the same coverage on `archive_sp_campaign`, which had none originally):

- 207-success body shape with filter assertion
- 207-error-list passthrough
- non-2xx HTTP failure

15 new tests total, all passing.

## Test plan

- [x] `uv run pytest tests/unit/test_archive_sp_*.py` — 15 passed
- [x] `uv run ruff check` — clean
- [x] End-to-end archive verified against SH US profile (12 dormant 2023-era SP campaigns archived 12-of-12, see commit `cac7889`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)