### PR TITLE
fix: close Windows CRLF write+read trap on v1 report-fields catalog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Packaged v1 report-fields catalog: SHA-256 in catalog_meta.json is a
+# byte-exact commit signal verified at runtime (see report_fields_v1_catalog.
+# _load_meta). Any line-ending translation breaks the integrity check on
+# Windows checkouts. Treat as binary so CRLF normalization never touches them.
+src/amazon_ads_mcp/resources/adsv1/*.json binary

--- a/src/amazon_ads_mcp/build/atomic_json.py
+++ b/src/amazon_ads_mcp/build/atomic_json.py
@@ -30,7 +30,11 @@ def save_json_atomic(path: Path, data: Mapping[str, Any]) -> None:
 
     tmp = path.with_suffix(path.suffix + ".tmp")
     try:
-        with open(tmp, "w", encoding="utf-8") as f:
+        # newline="\n": force LF on all platforms. Default text-mode `open`
+        # writes platform newlines (CRLF on Windows), which would produce
+        # CRLF bytes locally on a Windows refresh run and burn the SHA-256
+        # commit signal in catalog_meta.json for every Linux/CI reader.
+        with open(tmp, "w", encoding="utf-8", newline="\n") as f:
             json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
             f.write("\n")
         # NOTE: keep as `os.replace(tmp, path)` so tests can monkeypatch

--- a/tests/unit/test_cross_client_isolation.py
+++ b/tests/unit/test_cross_client_isolation.py
@@ -320,6 +320,14 @@ class TestAuthManagerEndToEndIsolation:
         monkeypatch.setattr(AuthManager, "_setup_provider", lambda self: None)
         self.manager = AuthManager()
 
+        # AuthManager.__init__ seeds _default_profile_id from
+        # settings.effective_profile_id, which is loaded from
+        # AMAZON_AD_API_PROFILE_ID at process start. A populated .env
+        # leaks a real profile ID into the test and breaks the
+        # "clear → None" assertion below. Force-clear so the fixture
+        # behaves identically on dev machines and CI.
+        self.manager._default_profile_id = None
+
         provider = StubProvider()
         provider.add_identity(_make_identity("id-A"))
         provider.add_identity(_make_identity("id-B"))

--- a/tests/unit/test_refresh_v1_catalog_writer.py
+++ b/tests/unit/test_refresh_v1_catalog_writer.py
@@ -102,9 +102,12 @@ def test_crash_before_replace_leaves_tmp_but_no_target(monkeypatch, tmp_path: Pa
 
 def test_ensure_ascii_false_preserves_unicode(tmp_path: Path):
     """Non-ASCII chars stored verbatim (matches reused template)."""
+    # read_text() defaults to locale encoding (cp1252 on en-US Windows),
+    # which mis-decodes UTF-8 bytes — assert against utf-8 explicitly so
+    # the test verifies bytes-as-written, not bytes-as-locale-interprets.
     target = tmp_path / "out.json"
     save_json_atomic(target, {"name": "café"})
-    assert "café" in target.read_text()
+    assert "café" in target.read_text(encoding="utf-8")
 
 
 def test_creates_parent_dirs_if_missing(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes a Windows-only failure mode in the v1 report-fields catalog SHA-256 commit-signal integrity check. 22 tests fail on every Windows checkout of `main` because `* text=auto` + `core.autocrlf=true` translate the packaged catalog JSON files from LF (as stored in git) to CRLF on disk, so on-disk SHAs never match the manifest in `catalog_meta.json`.

Four commits, three concerns, all scoped tightly:

| Commit | Concern | Tests fixed |
|---|---|---|
| `mark v1 catalog files binary in .gitattributes` | Stop CRLF translation on checkout (read side) | 20 (compatibility_graph + report_fields_*) |
| `force LF newline in save_json_atomic` | Stop CRLF emission when refresh runs on Windows (write side) | latent |
| `read UTF-8 explicitly in atomic_json writer test` | `read_text()` was using cp1252 on en-US Windows | 1 |
| `clear AuthManager._default_profile_id in cross-client isolation fixture` | `.env`-populated profile ID leaked into test | 1 |

Together they take a Windows dev-machine fast suite from 22 failed / 680 passed to 0 failed / 702 passed.

## Root causes

**Catalog SHA mismatch.** `catalog_meta.json` records SHA-256 of `dimensions.json`, `metrics.json`, `dimension_label_index.json` as a byte-exact commit signal (per the AGENTS.md "Behavioral guarantees locked by tests" section). The SHAs were computed against LF-encoded bytes (last refresh ran on macOS). On Windows checkout, `core.autocrlf=true` + `* text=auto` rewrite the files as CRLF on disk — every catalog read raises `CatalogSchemaError: interrupted refresh detected`. Marking them `binary` disables eol translation. Files are machine-generated; loss of textual diff display is acceptable.

**`save_json_atomic` writes platform newlines.** `open(tmp, "w", encoding="utf-8")` translates `\n` to `\r\n` on Windows. If anyone ever runs `refresh_v1_catalog` on a Windows host, the writer produces CRLF bytes locally, computes SHAs against those CRLF bytes, and the resulting commit breaks every Linux/CI reader. Adding `newline="\n"` forces LF on all platforms.

**Test uses locale-default decoding for UTF-8 bytes.** `Path.read_text()` without `encoding=` uses the locale encoding — cp1252 on en-US Windows. `save_json_atomic` writes UTF-8 (`ensure_ascii=False`), so the test's "café" round-trip mismatched on Windows. Pinning `encoding="utf-8"` makes the test verify bytes-as-written regardless of runner locale.

**Test fixture leaks `.env` into AuthManager.** `AuthManager.__init__` line 109 seeds `_default_profile_id` from `settings.effective_profile_id`, populated by `AMAZON_AD_API_PROFILE_ID`. A contributor with `.env` set sees their real profile ID where the test expects `None`. CI passes because no `.env` ships in the runner. Force-clearing the attribute after construction matches the test's documented intent ("Falls back to _default_profile_id (None)").

## Test plan

- [x] `uv run pytest -m "not slow"` — 702 passed, 3 skipped, 1 deselected, 0 failed (Windows 11, Python 3.11.12)
- [x] `uv run ruff check` — clean
- [x] Verified on-disk SHAs match `catalog_meta.json` after re-checkout under new `.gitattributes` rule
- [ ] CI on Linux runner — should remain green; none of the four commits change runtime behavior on Linux

## Notes for reviewer

- No catalog data files are modified — only the integrity-handling around them.
- The two `tests/unit/` changes use a single-line comment each to explain *why* the change is needed (per AGENTS.md test rationale convention).
- Cherry-picked from `rustydogbrands/main` (commits `86d183b`, `a0659bc`, `d5e6366`, `1a9c1ad`) where they've been validated for several hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)