### PR TITLE
fix: harden get_download_url against X-Forwarded header forgery

### DIFF
--- a/src/amazon_ads_mcp/server/builtin_tools.py
+++ b/src/amazon_ads_mcp/server/builtin_tools.py
@@ -951,14 +951,16 @@ Note: Requires HTTP transport (not stdio).
                 hint="Use list_downloads to see available files",
             )
 
-        # Build URL with proper encoding
-        base_url = str(request.base_url).rstrip("/")
+        # Build URL with proper encoding. Resolve the base URL through the
+        # same hardened helper the download routes use so this tool and the
+        # route that actually serves the file agree: prefer
+        # AMAZON_ADS_PUBLIC_BASE_URL, honor X-Forwarded-Proto/Host only when
+        # AMAZON_ADS_TRUST_FORWARDED_HEADERS=true, else fall back to the raw
+        # request base URL. Trusting forwarded headers unconditionally would
+        # let a client forge download URLs pointing at an attacker domain.
+        from .file_routes import _get_base_url
 
-        # Handle forwarded headers from reverse proxy
-        forwarded_proto = request.headers.get("X-Forwarded-Proto")
-        forwarded_host = request.headers.get("X-Forwarded-Host")
-        if forwarded_proto and forwarded_host:
-            base_url = f"{forwarded_proto}://{forwarded_host}"
+        base_url = _get_base_url(request)
 
         # URL-encode path segments
         encoded_path = "/".join(

--- a/tests/unit/test_download_paths.py
+++ b/tests/unit/test_download_paths.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastmcp import FastMCP
 
 from amazon_ads_mcp.tools import download_tools
 from amazon_ads_mcp.utils.paths import PathTraversalError, safe_join_within
@@ -138,3 +139,143 @@ async def test_get_download_metadata_accepts_nested(monkeypatch, profile_tree):
     )
     assert result["success"] is True
     assert result["metadata"]["k"] == "v"
+
+
+# ---------------------------------------------------------------------------
+# get_download_url tool: base-URL resolution must not trust forged headers
+#
+# These drive the real tool body (registered on a FastMCP server, invoked via
+# ``tool.fn``) so a regression that reintroduces inline X-Forwarded-* trust is
+# caught at the wire path, not just in the ``_get_base_url`` helper.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request as used by the tool."""
+
+    def __init__(self, base_url: str, headers: dict[str, str]) -> None:
+        self.base_url = base_url
+        self.headers = headers
+
+
+class _FakeAuthManager:
+    def __init__(self, profile_id: str) -> None:
+        self._profile_id = profile_id
+
+    def get_active_profile_id(self) -> str:
+        return self._profile_id
+
+
+async def _get_download_url_tool():
+    from amazon_ads_mcp.server.builtin_tools import register_download_tools
+
+    server = FastMCP("test-ads")
+    await register_download_tools(server)
+    tool = await server.get_tool("get_download_url")
+    assert tool is not None, "get_download_url should be registered"
+    return tool
+
+
+def _wire_tool_deps(monkeypatch, base: Path, profile_id: str, request: _FakeRequest):
+    """Patch the tool's runtime dependencies to drive its body offline.
+
+    Call this *after* fetching the tool: patching ``get_http_request`` earlier
+    also intercepts FastMCP's auth-context lookup inside ``get_tool``, which
+    expects a real request scope.
+    """
+    import amazon_ads_mcp.server.builtin_tools as builtin_tools
+    import amazon_ads_mcp.utils.export_download_handler as edh
+    import fastmcp.server.dependencies as deps
+
+    # The tool reads the HTTP request via a local import of get_http_request;
+    # patch the source module so the local import picks up our fake.
+    monkeypatch.setattr(deps, "get_http_request", lambda: request)
+    monkeypatch.setattr(
+        builtin_tools, "get_auth_manager", lambda: _FakeAuthManager(profile_id)
+    )
+    monkeypatch.setattr(edh, "get_download_handler", lambda: _FakeHandler(base))
+
+
+def _make_profile_file(base: Path, profile_id: str) -> str:
+    rel = "exports/campaigns/report.json"
+    target = base / "profiles" / profile_id / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{}")
+    return rel
+
+
+@pytest.mark.asyncio
+async def test_get_download_url_ignores_forged_headers_by_default(
+    monkeypatch, tmp_path
+):
+    """Without AMAZON_ADS_TRUST_FORWARDED_HEADERS, a client cannot steer the
+    generated download URL to an attacker host via X-Forwarded-* headers."""
+    monkeypatch.delenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", raising=False)
+    monkeypatch.delenv("AMAZON_ADS_PUBLIC_BASE_URL", raising=False)
+
+    profile_id = "test_profile"
+    rel = _make_profile_file(tmp_path, profile_id)
+    request = _FakeRequest(
+        base_url="http://localhost:9080/",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "attacker.example.com",
+        },
+    )
+    tool = await _get_download_url_tool()
+    _wire_tool_deps(monkeypatch, tmp_path, profile_id, request)
+    result = await tool.fn(ctx=None, file_path=rel)
+
+    assert result.success is True
+    assert "attacker.example.com" not in result.download_url
+    assert result.download_url.startswith("http://localhost:9080/downloads/")
+
+
+@pytest.mark.asyncio
+async def test_get_download_url_honors_forwarded_when_trusted(monkeypatch, tmp_path):
+    """When the operator opts in, the proxy's X-Forwarded-* headers are used —
+    proving the hardening is non-breaking for correctly configured proxies."""
+    monkeypatch.setenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", "true")
+    monkeypatch.delenv("AMAZON_ADS_PUBLIC_BASE_URL", raising=False)
+
+    profile_id = "test_profile"
+    rel = _make_profile_file(tmp_path, profile_id)
+    request = _FakeRequest(
+        base_url="http://localhost:9080/",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "ads.example.com",
+        },
+    )
+    tool = await _get_download_url_tool()
+    _wire_tool_deps(monkeypatch, tmp_path, profile_id, request)
+    result = await tool.fn(ctx=None, file_path=rel)
+
+    assert result.success is True
+    assert result.download_url.startswith("https://ads.example.com/downloads/")
+
+
+@pytest.mark.asyncio
+async def test_get_download_url_public_base_url_wins(monkeypatch, tmp_path):
+    """An explicit public base URL overrides even trusted forwarded headers."""
+    monkeypatch.setenv("AMAZON_ADS_PUBLIC_BASE_URL", "https://canonical.example.com/")
+    monkeypatch.setenv("AMAZON_ADS_TRUST_FORWARDED_HEADERS", "true")
+
+    profile_id = "test_profile"
+    rel = _make_profile_file(tmp_path, profile_id)
+    request = _FakeRequest(
+        base_url="http://localhost:9080/",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "attacker.example.com",
+        },
+    )
+    tool = await _get_download_url_tool()
+    _wire_tool_deps(monkeypatch, tmp_path, profile_id, request)
+    result = await tool.fn(ctx=None, file_path=rel)
+
+    assert result.success is True
+    assert result.download_url.startswith(
+        "https://canonical.example.com/downloads/"
+    )
+    assert "attacker.example.com" not in result.download_url


### PR DESCRIPTION
get_download_url built its download URL by unconditionally trusting the client-supplied X-Forwarded-Proto/Host headers, letting a caller forge a URL pointing at an attacker domain. Route base-URL resolution through the existing _get_base_url() helper (file_routes.py) so this tool matches the route that actually serves the file: prefer AMAZON_ADS_PUBLIC_BASE_URL, honor X-Forwarded-* only when AMAZON_ADS_TRUST_FORWARDED_HEADERS=true, else fall back to the raw request base URL.

Non-breaking: correctly configured proxy deployments (which set the trust flag or a public base URL) get identical URLs; only the unguarded header-trust misconfiguration changes. Adds wire-path tests that drive the real tool body and assert forged headers are ignored by default, honored when trusted, and overridden by an explicit public base URL.