### PR TITLE
feat: surface v1 reporting time-grain windows via report_fields(categ…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,26 @@ report_fields(mode="query", category="metric", search="cost", limit=20,
 - Byte-cap measurement factors `drop` in, so dropping populated arrays
   can also avoid description clipping when the post-drop payload fits.
 
-`category="filter"` and `category="time"` are accepted but return empty
-results in this release — use `list_report_fields(operation=...)` for
-filter/time baselines on other report APIs.
+`category="time"` returns the curated, doc-sourced time-grain catalog: the
+seven v1 reporting time dimensions (`hour/date/day/week/month/year/
+dateRange.value`) enriched with `date_range_presets`, `historical_data`, and
+`max_report_pull` per grain. These windows are NOT in the OpenAPI spec, so
+they close the time-axis equivalent of the field-discovery 400 loop (e.g.
+`hour.value` caps at a 14-day pull; `date.value` allows a 120-day pull but a
+15-month lookback). The overlay is a curated constant in
+`report_fields_v1_catalog.py` (not generated `dimensions.json`), so it does
+not affect catalog-drift checks, and it surfaces ONLY under `category="time"`
+— dimension/metric/`fields=[...]` output stays byte-identical.
+
+```
+report_fields(mode="query", category="time")           # all 7 grains + windows
+report_fields(mode="query", category="time",
+              drop=["date_range_presets"])              # name + window only
+```
+
+`category="filter"` is accepted but returns empty (no filter records in the
+v1 catalog yet) — use `list_report_fields(operation=...)` for filter
+baselines on other report APIs.
 
 ### Environment variables
 

--- a/src/amazon_ads_mcp/models/builtin_responses.py
+++ b/src/amazon_ads_mcp/models/builtin_responses.py
@@ -731,6 +731,19 @@ class ReportFieldEntry(BaseModel):
     v3_name_dsp: Optional[str] = None
     v3_name_sponsored_ads: Optional[str] = None
 
+    # v1 time-grain reporting windows (curated, doc-sourced). Populated only
+    # on records returned via ``category="time"``; None (and dropped via
+    # exclude_none) for every dimension/metric record, so non-time output is
+    # byte-identical to the prior shape. Source: Amazon Ads "Reporting time
+    # periods" guide — the date-range presets plus the historical-data and
+    # max-report-pull windows that bound a valid CreateReport time selection
+    # for each grain. Strings are verbatim from the doc (e.g. "15 months",
+    # "120 days") rather than normalized to days, since the doc mixes day and
+    # month units and month→day conversion would encode false precision.
+    date_range_presets: Optional[List[str]] = None
+    historical_data: Optional[str] = None
+    max_report_pull: Optional[str] = None
+
     source: Optional[CatalogSourceMeta] = None  # detail lookup only
 
 

--- a/src/amazon_ads_mcp/tools/report_fields_v1_catalog.py
+++ b/src/amazon_ads_mcp/tools/report_fields_v1_catalog.py
@@ -223,6 +223,151 @@ def get_metrics() -> List[Dict[str, Any]]:
     return _load_records("metrics")
 
 
+# ---------- curated time-grain windows (category="time") -----------------
+#
+# Doc-sourced overlay for the v1 reporting API's time grains. The packaged
+# OpenAPI spec does NOT enumerate per-grain date-range presets or the
+# historical-data / max-report-pull windows, so an LLM otherwise guesses a
+# time selection and eats an HTTP 400 — the same field-discovery failure the
+# rest of report_fields closes, extended to the time axis.
+#
+# This is a CURATED CONSTANT, not generated catalog content. It deliberately
+# lives in code (not in dimensions.json) so the refresh pipeline's
+# catalog-drift / idempotency guards stay green and the loader's "four named
+# files" contract is untouched. The descriptive text (display_name,
+# short_description, data_type) mirrors the corresponding catalog dimension
+# records so the two views agree.
+#
+# Mapping note: the Amazon doc lists a "Day of week" grain with no
+# corresponding catalog field_id (the catalog's ``day.value`` is "Day of
+# Month"), so it is intentionally omitted rather than mapped to a phantom id.
+#
+# Source: Amazon Ads "Reporting — time periods" guide (date-range presets,
+# historical data, and max report pull per time dimension).
+_TIME_PRESETS_HOUR = ["Today", "Yesterday", "Last 7 days", "This week", "Last week"]
+_TIME_PRESETS_DATE = _TIME_PRESETS_HOUR + [
+    "Last 30 days",
+    "This month",
+    "Last month",
+    "Last 90 days",
+    "This quarter",
+]
+_TIME_PRESETS_YEARLY = _TIME_PRESETS_DATE + ["This year"]
+_TIME_PRESETS_FULL = _TIME_PRESETS_YEARLY + ["Last year"]
+
+#: Time-grain records in catalog-record shape, carrying the curated window
+#: overlay. ``category="time"`` so they read as a distinct discovery facet;
+#: the same field_ids also exist as ``category="dimension"`` catalog records
+#: (their compatibility-graph home). Returned via :func:`get_time_records`.
+TIME_GRAIN_RECORDS: List[Dict[str, Any]] = [
+    {
+        "field_id": "hour.value",
+        "display_name": "Hour (Primary Key)",
+        "data_type": "LONG",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The hour of the day associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_HOUR),
+        "historical_data": "14 days",
+        "max_report_pull": "14 days",
+    },
+    {
+        "field_id": "date.value",
+        "display_name": "Date (Primary Key)",
+        "data_type": "DATE",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The date included in the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_DATE),
+        "historical_data": "15 months",
+        "max_report_pull": "120 days",
+    },
+    {
+        "field_id": "day.value",
+        "display_name": "Day of Month (Primary Key)",
+        "data_type": "LONG",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The day of the month associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_YEARLY),
+        "historical_data": "15 months",
+        "max_report_pull": "15 months",
+    },
+    {
+        "field_id": "week.value",
+        "display_name": "Week (Primary Key)",
+        "data_type": "LONG",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The week of the year associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_YEARLY),
+        "historical_data": "15 months",
+        "max_report_pull": "15 months",
+    },
+    {
+        "field_id": "month.value",
+        "display_name": "Month (Primary Key)",
+        "data_type": "LONG",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The month of the year associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_FULL),
+        "historical_data": "72 months",
+        "max_report_pull": "25 months",
+    },
+    {
+        "field_id": "year.value",
+        "display_name": "Year (Primary Key)",
+        "data_type": "LONG",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The year associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_FULL),
+        "historical_data": "72 months",
+        "max_report_pull": "72 months",
+    },
+    {
+        "field_id": "dateRange.value",
+        "display_name": "Date range (Primary Key)",
+        "data_type": "DATE_RANGE",
+        "category": "time",
+        "provenance": "documented",
+        "short_description": "The date range associated with the report.",
+        "required_fields": [],
+        "complementary_fields": [],
+        "date_range_presets": list(_TIME_PRESETS_FULL),
+        "historical_data": "72 months",
+        "max_report_pull": "72 months",
+    },
+]
+
+
+def get_time_records() -> List[Dict[str, Any]]:
+    """Return deep copies of the curated time-grain records.
+
+    Independent of the loaded catalog files — the window overlay is a
+    code-level constant, so this works even when the on-disk catalog has no
+    time dimensions. Copies are returned so callers can mutate freely
+    without corrupting the shared constant.
+    """
+    return [
+        {**rec, "date_range_presets": list(rec["date_range_presets"])}
+        for rec in TIME_GRAIN_RECORDS
+    ]
+
+
 def lookup_field(field_id: str) -> Optional[Dict[str, Any]]:
     """O(routing+linear) single-field detail lookup.
 

--- a/src/amazon_ads_mcp/tools/report_fields_v1_handler.py
+++ b/src/amazon_ads_mcp/tools/report_fields_v1_handler.py
@@ -437,6 +437,12 @@ def _record_to_entry(
         description=record.get("description") if include_description else None,
         required_fields=list(record.get("required_fields") or []),
         complementary_fields=list(record.get("complementary_fields") or []),
+        # Curated time-grain window overlay (category="time" records only).
+        # None for every dimension/metric record → dropped by exclude_none,
+        # keeping non-time output byte-identical to the prior shape.
+        date_range_presets=_nonempty_or_none("date_range_presets"),
+        historical_data=record.get("historical_data"),
+        max_report_pull=record.get("max_report_pull"),
         compatible_dimensions=_nonempty_or_none("compatible_dimensions"),
         incompatible_dimensions=_nonempty_or_none("incompatible_dimensions"),
         # Round 13 Phase D: parallel field-id arrays. Display strings
@@ -527,8 +533,12 @@ def _select_query_records(inp: ReportFieldsInput) -> List[Dict[str, Any]]:
     Does NOT apply pagination, search, fields-lookup, or v3 gating;
     those are layered on top.
     """
-    # category=filter or time → empty; they carry no records in v1 catalog yet (§D.2).
-    if inp.category in ("filter", "time"):
+    # category=time → curated doc-sourced grain records (presets + historical
+    # data + max report pull). category=filter stays empty: the v1 catalog
+    # carries no filter records yet (§D.2).
+    if inp.category == "time":
+        return list(catalog_mod.get_time_records())
+    if inp.category == "filter":
         return []
 
     if inp.category == "dimension":

--- a/tests/unit/test_report_fields_handler_semantics.py
+++ b/tests/unit/test_report_fields_handler_semantics.py
@@ -175,16 +175,64 @@ def test_category_dimension_filters_correctly(small_catalog):
 
 
 def test_category_filter_returns_empty(small_catalog):
-    """filter/time accepted but return empty — no informational note added (§D.2)."""
+    """filter accepted but returns empty — no records in the v1 catalog (§D.2)."""
     r = handle(mode="query", category="filter")
     assert r.fields == []
     assert r.total_matching == 0
 
 
-def test_category_time_returns_empty(small_catalog):
-    r = handle(mode="query", category="time")
-    assert r.fields == []
-    assert r.total_matching == 0
+def test_category_time_returns_grains(small_catalog):
+    """category="time" returns the curated doc-sourced grain records with
+    reporting-window metadata, independent of the loaded catalog (the
+    small_catalog fixture has no time dimensions)."""
+    r = handle(mode="query", category="time", limit=100)
+    ids = [e.field_id for e in r.fields]
+    assert ids == [
+        "date.value",
+        "dateRange.value",
+        "day.value",
+        "hour.value",
+        "month.value",
+        "week.value",
+        "year.value",
+    ]
+    assert r.total_matching == 7
+
+    by_id = {e.field_id: e for e in r.fields}
+    # Tightest window: hour caps at 14 days of pull + 14 days lookback.
+    hour = by_id["hour.value"]
+    assert hour.category == "time"
+    assert hour.max_report_pull == "14 days"
+    assert hour.historical_data == "14 days"
+    assert hour.date_range_presets == [
+        "Today",
+        "Yesterday",
+        "Last 7 days",
+        "This week",
+        "Last week",
+    ]
+    # Date grain: 120-day pull but 15-month lookback (the classic 400 trap).
+    assert by_id["date.value"].max_report_pull == "120 days"
+    assert by_id["date.value"].historical_data == "15 months"
+    # Widest: year/dateRange pull the full 72 months.
+    assert by_id["year.value"].max_report_pull == "72 months"
+    assert by_id["dateRange.value"].historical_data == "72 months"
+
+
+def test_category_time_grains_absent_from_dimension_path(small_catalog):
+    """The curated time overlay must NOT leak into the dimension/metric or
+    all-category paths — those stay catalog-truth and byte-identical."""
+    dims = handle(mode="query", category="dimension")
+    assert [e.field_id for e in dims.fields] == ["campaign.id", "campaign.name"]
+    for e in dims.fields:
+        assert e.date_range_presets is None
+        assert e.max_report_pull is None
+        assert e.historical_data is None
+
+    # Search runs over the catalog pool, not the time overlay — a grain id
+    # would only appear here if the overlay leaked into the general path.
+    searched = handle(mode="query", search="hour", limit=100)
+    assert "hour.value" not in {e.field_id for e in searched.fields}
 
 
 def test_search_substring_on_both_field_id_and_display_name(small_catalog):


### PR DESCRIPTION
The overlay is a curated, doc-sourced constant in report_fields_v1_catalog.py (not generated dimensions.json), so catalog-drift / idempotency guards and the loader's four-named-files contract are untouched. The three new ReportFieldEntry fields are Optional and dropped via exclude_none, so dimension/metric/fields=[] output stays byte-identical; the overlay surfaces only under category="time".

Source: Amazon Ads reporting time-periods guide. The doc's 'Day of week' grain has no catalog field_id (day.value is 'Day of Month') and is intentionally omitted rather than mapped to a phantom id. validate-mode date-range pre-flight is left as a follow-up.