### PR TITLE
feat: add usage metering producer adapter (mcp-outbound-metering)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,12 +170,17 @@ jobs:
   # ----- Metering conformance (Task 22) ----------------------------------
   #
   # mcp-outbound-metering is a git dependency on the PRIVATE KuudoAI/billing
-  # repo (pyproject.toml [tool.uv.sources], python_version >= '3.12' only)
-  # -- `uv sync` needs authenticated git access to fetch it, hence the
-  # BILLING_REPO_TOKEN secret + git insteadOf step below. Python 3.12 only:
-  # every tests/metering/ test is skipif-guarded to <3.12, and
-  # mcp-outbound-metering itself is never installed below 3.12 (the repo's
-  # own floor stays 3.10 -- see the `tests` job's matrix above, untouched).
+  # repo (pyproject.toml [tool.uv.sources]), gated behind the OPTIONAL
+  # "metering" extra (fix round 2, deployment gap #2) -- it is NOT in
+  # [project.dependencies], so it is only ever fetched when a sync
+  # explicitly requests `--extra metering`, as this job does below. Every
+  # OTHER job in this file (smoke/tests/catalog-negative/wheel-smoke) runs
+  # a plain `uv sync --frozen` with no extra and therefore never touches
+  # the private repo or needs BILLING_REPO_TOKEN, even on their 3.12 legs.
+  # Python 3.12 only: every tests/metering/ test is skipif-guarded to
+  # <3.12, and mcp-outbound-metering itself is never installable below
+  # 3.12 (the repo's own floor stays 3.10 -- see the `tests` job's matrix
+  # above, untouched).
   metering:
     name: Metering conformance (Task 22)
     runs-on: ubuntu-latest
@@ -212,7 +217,7 @@ jobs:
 
       - name: Install dependencies (metering extra resolved on 3.12)
         run: |
-          uv sync --frozen --python 3.12
+          uv sync --frozen --python 3.12 --extra metering
 
       - name: Run metering test suite
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,16 @@ jobs:
       # credential or endpoint. --skip-ingest: no real edge/ingest
       # endpoint exists yet for this integration (registration/activation
       # is a separate, later, edge-side step per design §3.5.6).
+      #
+      # DEPLOYMENT NOTE (fix round 1, MINOR): a single NA host is
+      # sufficient here -- this step only exercises the conformance
+      # suite's mock upstream, never real regional traffic. A REAL
+      # production METERING_UPSTREAM_HOSTS value must list all three
+      # Amazon Ads regional hosts (advertising-api.amazon.com, -eu, -fe;
+      # plus the "-test" sandbox variants if AMAZON_ADS_SANDBOX_MODE is
+      # used) -- see metering.yaml's own comment. With
+      # disallowed_host_action: reject, a production value listing only
+      # the NA host would reject every EU/FE request outright.
       - name: mcp-metering verify
         env:
           METERING_ENABLED: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,77 @@ jobs:
       - name: Run slow-marker suite (wheel-content + smoke)
         run: |
           uv run pytest -q -m slow
+
+  # ----- Metering conformance (Task 22) ----------------------------------
+  #
+  # mcp-outbound-metering is a git dependency on the PRIVATE KuudoAI/billing
+  # repo (pyproject.toml [tool.uv.sources], python_version >= '3.12' only)
+  # -- `uv sync` needs authenticated git access to fetch it, hence the
+  # BILLING_REPO_TOKEN secret + git insteadOf step below. Python 3.12 only:
+  # every tests/metering/ test is skipif-guarded to <3.12, and
+  # mcp-outbound-metering itself is never installed below 3.12 (the repo's
+  # own floor stays 3.10 -- see the `tests` job's matrix above, untouched).
+  metering:
+    name: Metering conformance (Task 22)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Fail loudly and early, before `uv sync` turns a missing secret
+      # into a confusing git-auth error. NOTE (operator action required):
+      # BILLING_REPO_TOKEN must be provisioned as a repo/org secret -- a
+      # GitHub PAT (classic or fine-grained) with at least read access to
+      # KuudoAI/billing. This job cannot run without it.
+      - name: Verify BILLING_REPO_TOKEN is provisioned
+        env:
+          BILLING_REPO_TOKEN: ${{ secrets.BILLING_REPO_TOKEN }}
+        run: |
+          if [ -z "$BILLING_REPO_TOKEN" ]; then
+            echo "::error::BILLING_REPO_TOKEN secret is not set. mcp-outbound-metering is pulled from the private KuudoAI/billing repo via a git dependency (pyproject.toml [tool.uv.sources]), and 'uv sync' needs authenticated git access to fetch it. Provision a GitHub token (read access to KuudoAI/billing) as the BILLING_REPO_TOKEN repository/organization secret."
+            exit 1
+          fi
+
+      - name: Configure git auth for the private billing repo
+        env:
+          BILLING_REPO_TOKEN: ${{ secrets.BILLING_REPO_TOKEN }}
+        run: |
+          git config --global url."https://x-access-token:${BILLING_REPO_TOKEN}@github.com/KuudoAI/billing".insteadOf "https://github.com/KuudoAI/billing"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies (metering extra resolved on 3.12)
+        run: |
+          uv sync --frozen --python 3.12
+
+      - name: Run metering test suite
+        env:
+          MCP_TEST_COMPAT: "true"
+        run: |
+          uv run pytest tests/metering -q
+
+      # Conformance-only fakes (integration guide §4's CI environment
+      # block, adapted to this repo's provider/host) -- never a real
+      # credential or endpoint. --skip-ingest: no real edge/ingest
+      # endpoint exists yet for this integration (registration/activation
+      # is a separate, later, edge-side step per design §3.5.6).
+      - name: mcp-metering verify
+        env:
+          METERING_ENABLED: "true"
+          METERING_UPSTREAM_HOSTS: "advertising-api.amazon.com"
+          METERING_UPSTREAM_SERVICE: "amazon_ads"
+          METERING_ENDPOINT: "https://ingest.example-metering.test/v1/usage/batches"
+          METERING_DEPLOYMENT_ID: "ci"
+          METERING_INSTANCE_ID: "ci-1"
+          METERING_KEY_ID: "ci-key-placeholder"
+          METERING_HMAC_SECRET: "ci-secret-placeholder"
+          METERING_OUTBOX_MAX_BYTES: "10000000"
+        run: |
+          uv run mcp-metering verify --config metering.yaml \
+            --harness amazon_ads_mcp.metering.conformance:create_conformance_harness \
+            --skip-ingest

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,35 @@ ARG PYTHON_VERSION=3.14
 ARG APP_UID=10001
 ARG APP_GID=10001
 
+# Metering (Task 22) is gated behind a build ARG, default OFF:
+#
+#   INCLUDE_METERING=false (default) -- `docker build .` with no
+#     --build-arg needed. mcp-outbound-metering (a PRIVATE git
+#     dependency, pyproject.toml [tool.uv.sources]) lives behind the
+#     optional "metering" extra (pyproject.toml
+#     [project.optional-dependencies]), never [project.dependencies], so
+#     a default build never touches the private repo and needs no
+#     credential at all.
+#   INCLUDE_METERING=true -- installs the "metering" extra. Requires a
+#     `billing_repo_token` BuildKit secret (a GitHub token with read
+#     access to KuudoAI/billing) for `uv sync` to fetch the private
+#     dependency, e.g.:
+#       docker build --build-arg INCLUDE_METERING=true \
+#         --secret id=billing_repo_token,env=BILLING_REPO_TOKEN .
+#     The token is consumed via ephemeral GIT_CONFIG_* env vars scoped to
+#     the single RUN step that needs it (see below) -- never written to
+#     ~/.gitconfig or any other file, so it can never leak into an image
+#     layer. At runtime, METERING_ENABLED=true resolves metering.yaml
+#     from the packaged copy (amazon_ads_mcp/metering/metering.yaml,
+#     fix round 2 deployment gap #1) with zero extra COPY needed here --
+#     it ships inside the wheel/venv installed below.
+#
+# See docs/metering.md for both modes end to end, including the runtime
+# env vars (METERING_ENABLED, METERING_UPSTREAM_HOSTS, etc.) neither mode
+# sets here -- those are always supplied at `docker run`/compose time via
+# a secrets manager, never baked into the image.
+ARG INCLUDE_METERING=false
+
 # Pull the uv standalone binary as a build-stage helper image. Pinning
 # the uv tag (not :latest) keeps `uv sync` reproducible across builds.
 FROM ghcr.io/astral-sh/uv:0.9.5 AS uv-bin
@@ -30,6 +59,9 @@ FROM ghcr.io/astral-sh/uv:0.9.5 AS uv-bin
 # Stage 1: builder
 # ---------------------------------------------------------------------------
 FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
+
+# Re-declare to bring the global ARG into this stage's scope.
+ARG INCLUDE_METERING
 
 # UV_LINK_MODE=copy is required when using the cache mount below — uv's
 # default 'hardlink' mode breaks across the mount boundary.
@@ -47,20 +79,61 @@ WORKDIR /app
 
 COPY --from=uv-bin /uv /uvx /bin/
 
+# git is required to resolve mcp-outbound-metering (a git dependency,
+# pyproject.toml [tool.uv.sources]) whenever INCLUDE_METERING=true --
+# python:*-slim-bookworm does not ship it. Installed unconditionally
+# (cheap, cached, and this builder stage is discarded -- only /opt/venv
+# is copied into the runtime image below, so this never affects final
+# image size or the default INCLUDE_METERING=false build's footprint).
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends git
+
 # Layer-cache friendly: install the dep graph before copying source.
 # `--no-install-project --no-editable` resolves and installs only deps so
 # this layer survives source-only changes.
+#
+# The `billing_repo_token` secret is only ever READ inside this one RUN
+# step, and only when INCLUDE_METERING=true -- via GIT_CONFIG_COUNT/
+# GIT_CONFIG_KEY_0/GIT_CONFIG_VALUE_0 env vars scoped to this shell
+# process only. Nothing writes it to ~/.gitconfig or any other file, so
+# it never persists into this (or any) image layer. `required=false`
+# keeps the default INCLUDE_METERING=false build working with no secret
+# provided at all.
 COPY pyproject.toml uv.lock README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=secret,id=billing_repo_token,required=false \
     uv venv /opt/venv && \
-    uv sync --no-dev --frozen --extra code-mode --no-install-project --no-editable
+    EXTRAS="--extra code-mode" && \
+    if [ "$INCLUDE_METERING" = "true" ]; then \
+        EXTRAS="$EXTRAS --extra metering"; \
+        if [ -s /run/secrets/billing_repo_token ]; then \
+            export GIT_CONFIG_COUNT=1; \
+            export GIT_CONFIG_KEY_0="url.https://x-access-token:$(cat /run/secrets/billing_repo_token)@github.com/KuudoAI/billing.insteadOf"; \
+            export GIT_CONFIG_VALUE_0="https://github.com/KuudoAI/billing"; \
+        fi; \
+    fi && \
+    uv sync --no-dev --frozen $EXTRAS --no-install-project --no-editable
 
 # Now bring in the project itself and install it on top of the cached deps.
 # pyproject.toml uses build_package.py as an in-tree PEP 517 backend.
+# Same EXTRAS/secret handling as above -- uv's extras set must stay
+# consistent across both syncs, or this second (no-extras) sync would
+# uninstall mcp-outbound-metering that the first sync just installed.
 COPY build_package.py ./
 COPY src/ src/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-dev --frozen --extra code-mode --no-editable
+    --mount=type=secret,id=billing_repo_token,required=false \
+    EXTRAS="--extra code-mode" && \
+    if [ "$INCLUDE_METERING" = "true" ]; then \
+        EXTRAS="$EXTRAS --extra metering"; \
+        if [ -s /run/secrets/billing_repo_token ]; then \
+            export GIT_CONFIG_COUNT=1; \
+            export GIT_CONFIG_KEY_0="url.https://x-access-token:$(cat /run/secrets/billing_repo_token)@github.com/KuudoAI/billing.insteadOf"; \
+            export GIT_CONFIG_VALUE_0="https://github.com/KuudoAI/billing"; \
+        fi; \
+    fi && \
+    uv sync --no-dev --frozen $EXTRAS --no-editable
 
 # ---------------------------------------------------------------------------
 # Stage 2: runtime

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,12 @@ services:
         BUILD_TIME: ${BUILD_TIME:-unknown}
         APP_UID: "10001"
         APP_GID: "10001"
+        # Metering (Task 22), default OFF -- see docs/metering.md and the
+        # Dockerfile's own comments for both modes. Set INCLUDE_METERING=true
+        # in the shell (plus a `billing_repo_token` BuildKit secret) to build
+        # an image with metering support; the default build stays
+        # completely token-free.
+        INCLUDE_METERING: ${INCLUDE_METERING:-false}
     image: amazon-ads-mcp:latest
     container_name: amazon-ads-mcp
     env_file:

--- a/docs/metering.md
+++ b/docs/metering.md
@@ -1,0 +1,146 @@
+# Usage metering (Task 22)
+
+Meters every real Amazon Ads API call through `AuthenticatedClient` (both
+construction paths, plus `ResilientAuthenticatedClient`) via the
+`mcp-outbound-metering` producer runtime (billing repo,
+`packages/python/mcp_outbound_metering`). OAuth/OpenBridge/Kuudo provider
+clients are structurally unmetered -- they never construct
+`AuthenticatedClient`. Off by default everywhere; enabling it is an
+explicit, opt-in operator decision, described below.
+
+## Two install modes
+
+`mcp-outbound-metering` is a **private** git dependency (`pyproject.toml`
+`[tool.uv.sources]`, `KuudoAI/billing`), Python>=3.12 only, and lives
+behind the optional `metering` extra -- **never** a base dependency. A
+plain install/sync (`uv sync`, `pip install .`, the default Docker build)
+never touches the private repo and needs no credential, on any Python
+version.
+
+### 1. Local / non-Docker install
+
+```bash
+# Default -- no metering support, no private-repo access:
+uv sync
+pip install .
+
+# With metering support (Python>=3.12 required):
+uv sync --extra metering
+pip install '.[metering]'
+```
+
+### 2. Docker
+
+The `Dockerfile` gates the extra behind a build ARG, default OFF:
+
+```bash
+# Default -- token-free, exactly like every other default build:
+docker build -t amazon-ads-mcp .
+
+# With metering support -- requires a `billing_repo_token` BuildKit
+# secret (a GitHub token with read access to KuudoAI/billing):
+docker build --build-arg INCLUDE_METERING=true \
+  --secret id=billing_repo_token,env=BILLING_REPO_TOKEN \
+  -t amazon-ads-mcp .
+```
+
+`docker-compose.yaml` reads the same toggle from an `INCLUDE_METERING`
+shell/`.env` variable (default `false`) for `docker compose build`.
+
+The token is consumed entirely through ephemeral
+`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` environment
+variables scoped to the single `RUN` step that needs them -- it is never
+written to `~/.gitconfig` or any other file, so it cannot leak into an
+image layer even if that layer is cached/pushed. See the `Dockerfile`'s
+own comments for the exact mechanism.
+
+## Config resolution (works in every deployment shape)
+
+`metering.yaml` is tracked at the repo root **and** packaged as
+`amazon_ads_mcp/metering/metering.yaml` (byte-identical -- a drift-guard
+test fails loudly if they ever diverge). A Docker runtime image copies
+the venv + `dist/openapi/` + the entrypoint into `/app`, never a repo
+checkout, and a wheel install only ships packaged resources -- so
+`amazon_ads_mcp.metering.config.resolve_config_path()` resolves in this
+order:
+
+1. `METERING_CONFIG` env var, if set -- explicit operator override.
+2. `./metering.yaml` relative to CWD, if present -- dev convenience
+   (running from a repo checkout finds the tracked file with zero
+   configuration).
+3. The packaged copy, via `importlib.resources` -- works from a wheel
+   install and a Docker image's site-packages, independent of CWD. This
+   is what a packaged/Docker deployment actually uses.
+
+## Enabling at runtime
+
+None of the `METERING_*` values are ever baked into the image or the
+repo -- they are always supplied at `docker run`/compose time via a
+secrets manager, exactly like every other credential this project uses.
+Minimum set to enable:
+
+```bash
+METERING_ENABLED=true
+METERING_UPSTREAM_HOSTS=advertising-api.amazon.com,advertising-api-eu.amazon.com,advertising-api-fe.amazon.com
+METERING_UPSTREAM_SERVICE=amazon_ads
+METERING_ENDPOINT=<your ingest endpoint>
+METERING_DEPLOYMENT_ID=<per-deployment id>
+METERING_INSTANCE_ID=<per-replica id>
+METERING_KEY_ID=<signing key id>
+METERING_HMAC_SECRET=<signing secret>
+METERING_OUTBOX_MAX_BYTES=10000000
+```
+
+**Regional hosts, production**: `METERING_UPSTREAM_HOSTS` must list all
+three Amazon Ads regional hosts before enabling in production --
+`advertising-api.amazon.com`, `advertising-api-eu.amazon.com`,
+`advertising-api-fe.amazon.com` -- plus the `-test` sandbox variants if
+`AMAZON_ADS_SANDBOX_MODE` is used. The host match is exact, never a
+suffix/wildcard (`RegionConfig.API_HOSTS`, `utils/region_config.py`), and
+`metering.yaml`'s `disallowed_host_action` is `reject`: listing only the
+NA host rejects every EU/FE request outright the moment an
+identity/marketplace routes to a regional endpoint that isn't
+allowlisted.
+
+**Billing-critical startup rule**: `METERING_ENABLED=true` (exactly,
+case-insensitive) that fails to start (Python<3.12, the `metering` extra
+not installed, a bad config, etc.) **fails server startup** -- the server
+refuses to accept traffic without metering rather than silently running
+unmetered (design §7.3). Any other truthy-but-not-exactly-`"true"` value
+attempts startup (so a genuine misconfiguration is logged, not silently
+ignored) but degrades non-fatally on failure. Unset/`false`/empty is a
+silent no-op, the default.
+
+If `METERING_ENABLED=true` (strict) and the `metering` extra isn't
+installed, startup fails with a message naming the exact fix:
+
+```
+METERING_ENABLED=true but metering is unavailable (requires Python>=3.12
+and the optional 'metering' extra installed -- run pip/uv install
+'amazon-ads-mcp[metering]'); refusing to start without metering
+```
+
+## CI
+
+`.github/workflows/ci.yml`'s `metering` job (Python 3.12 only) syncs with
+`--extra metering` (needs `BILLING_REPO_TOKEN`), runs
+`uv run pytest tests/metering -q`, then `uv run mcp-metering verify
+--config metering.yaml --harness
+amazon_ads_mcp.metering.conformance:create_conformance_harness
+--skip-ingest`. Every other job (`smoke`, `tests`, `catalog-negative`,
+`wheel-smoke`) runs a plain `uv sync --frozen` with no extra and never
+touches the private repo, on any Python version in their matrices.
+
+## Source layout
+
+- `metering.yaml` (repo root, tracked) / `src/amazon_ads_mcp/metering/metering.yaml`
+  (packaged, byte-identical) -- the adapter config.
+- `src/amazon_ads_mcp/metering/` -- `compat.py` (the <3.12 + missing-extra
+  guard), `adapter.py` (`LazyMeteredTransport`, the transport-install
+  seam), `attribution.py` (`tool_name` ContextVar + middleware),
+  `context.py`/`normalizer.py` (dimension + path-normalizer providers),
+  `config.py` (config path resolution), `lifespan.py` (start/stop +
+  health payload), `conformance.py` (the `mcp-metering verify` /
+  `ProducerConformanceSuite` harness factory).
+- `tests/metering/` -- the full test suite (skipif-guarded to Python>=3.12
+  wherever it needs the real `mcp_outbound_metering` package).

--- a/metering.yaml
+++ b/metering.yaml
@@ -1,0 +1,35 @@
+# Adapter config for amazon_ads_mcp (Task 22), generated per the
+# `mcp-metering install` scaffold and hand-adapted into
+# src/amazon_ads_mcp/metering/ (design §3.5.2). Non-secret: every *_env
+# key below names an environment variable this file never reads a value
+# for. Credentials, account mappings, sink routes, and pricing never
+# belong here (design §3.5.3).
+schema_version: 1
+source_id: amazon_ads_mcp
+provider:
+  service: amazon_ads
+  exact_hosts_env: METERING_UPSTREAM_HOSTS
+  disallowed_host_action: reject
+# Declarative only -- nothing in mcp-outbound-metering reads
+# context_provider/path_normalizer off this file at runtime; they are
+# wired by hand in src/amazon_ads_mcp/metering/adapter.py via
+# MeteringRuntime.wrap_transport() (design §3.5.4). If either of these
+# modules is ever relocated, update these strings too -- they are plain
+# strings naming an importable module path, not a live Python reference.
+transport:
+  adapter: httpx
+  context_provider: amazon_ads_mcp.metering.context:usage_context
+  path_normalizer: amazon_ads_mcp.metering.normalizer:normalize_path
+# Allowlist (Task 22 ruling #4). operation_id/api_group are intentionally
+# omitted in v1 -- no HTTP-layer source exists for either without a
+# template_resolver (post-v1, design §3.2).
+dimensions:
+  - identity_id
+  - profile_id
+  - region
+  - auth_method
+  - tool_name
+outbox:
+  mode: sqlite
+  path_env: METERING_OUTBOX_PATH
+  max_bytes_env: METERING_OUTBOX_MAX_BYTES

--- a/metering.yaml
+++ b/metering.yaml
@@ -8,6 +8,21 @@ schema_version: 1
 source_id: amazon_ads_mcp
 provider:
   service: amazon_ads
+  # DEPLOYMENT NOTE (fix round 1, MINOR): the host match is EXACT, never
+  # a suffix/wildcard, and Amazon Ads is a 3-region API
+  # (RegionConfig.API_HOSTS: na/eu/fe, utils/region_config.py).
+  # METERING_UPSTREAM_HOSTS must list ALL THREE regional hosts before
+  # enabling in production --
+  #   advertising-api.amazon.com, advertising-api-eu.amazon.com,
+  #   advertising-api-fe.amazon.com
+  # -- plus the sandbox "-test" variants
+  # (advertising-api-test.amazon.com, advertising-api-eu-test.amazon.com,
+  # advertising-api-fe-test.amazon.com) if AMAZON_ADS_SANDBOX_MODE is
+  # ever used. With disallowed_host_action: reject (below), listing only
+  # the NA host breaks EU/FE traffic outright the moment an
+  # identity/marketplace routes a request to a regional endpoint that
+  # isn't allowlisted -- every such call raises DisallowedHostError
+  # instead of reaching Amazon.
   exact_hosts_env: METERING_UPSTREAM_HOSTS
   disallowed_host_action: reject
 # Declarative only -- nothing in mcp-outbound-metering reads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.27"
 description = "Amazon Ads API MCP Server - Implementation for Amazon Advertising API"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
-dependencies = [ "fastmcp[tasks]>=3.4.2,<4", "python-dotenv>=1.2.1", "pydantic>=2.12.5", "pydantic-settings>=2.12.0", "httpx[http2]>=0.28.1", "pyjwt>=2.10.1", "cryptography>=41.0.0", "openai>=1.109.1", "PyYAML>=6.0.2", "tiktoken>=0.12.0", "jsonschema>=4.25.1", "mcp-outbound-metering[verify] ; python_version >= '3.12'",]
+dependencies = [ "fastmcp[tasks]>=3.4.2,<4", "python-dotenv>=1.2.1", "pydantic>=2.12.5", "pydantic-settings>=2.12.0", "httpx[http2]>=0.28.1", "pyjwt>=2.10.1", "cryptography>=41.0.0", "openai>=1.109.1", "PyYAML>=6.0.2", "tiktoken>=0.12.0", "jsonschema>=4.25.1",]
 [[project.authors]]
 name = "Amazon Ads API MCP SDK"
 
@@ -22,6 +22,7 @@ dev = [ "black>=25.12,<27.0", "isort>=7,<9", "mypy>=1.19.1", "pytest>=9.0.2", "p
 [project.optional-dependencies]
 audit = [ "tiktoken>=0.7.0", "rich>=13.0",]
 code-mode = [ "fastmcp[code-mode]>=3.4.2,<4",]
+metering = [ "mcp-outbound-metering ; python_version >= '3.12'",]
 
 [project.license]
 text = "MIT"
@@ -86,6 +87,10 @@ format = "wheel"
 
 [[tool.poetry.include]]
 path = "src/amazon_ads_mcp/resources/contract/jsonschema_error_codes.json"
+format = "wheel"
+
+[[tool.poetry.include]]
+path = "src/amazon_ads_mcp/metering/metering.yaml"
 format = "wheel"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.27"
 description = "Amazon Ads API MCP Server - Implementation for Amazon Advertising API"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
-dependencies = [ "fastmcp[tasks]>=3.4.2,<4", "python-dotenv>=1.2.1", "pydantic>=2.12.5", "pydantic-settings>=2.12.0", "httpx[http2]>=0.28.1", "pyjwt>=2.10.1", "cryptography>=41.0.0", "openai>=1.109.1", "PyYAML>=6.0.2", "tiktoken>=0.12.0", "jsonschema>=4.25.1",]
+dependencies = [ "fastmcp[tasks]>=3.4.2,<4", "python-dotenv>=1.2.1", "pydantic>=2.12.5", "pydantic-settings>=2.12.0", "httpx[http2]>=0.28.1", "pyjwt>=2.10.1", "cryptography>=41.0.0", "openai>=1.109.1", "PyYAML>=6.0.2", "tiktoken>=0.12.0", "jsonschema>=4.25.1", "mcp-outbound-metering[verify] ; python_version >= '3.12'",]
 [[project.authors]]
 name = "Amazon Ads API MCP SDK"
 
@@ -12,6 +12,9 @@ name = "Amazon Ads API MCP SDK"
 requires = [ "poetry-core",]
 build-backend = "build_package"
 backend-path = [ ".",]
+
+[tool.uv.sources]
+mcp-outbound-metering = { git = "https://github.com/KuudoAI/billing", subdirectory = "packages/python/mcp_outbound_metering", rev = "ef8f71ee722c35265050c38fb34f9a9ea36122da" }
 
 [dependency-groups]
 dev = [ "black>=25.12,<27.0", "isort>=7,<9", "mypy>=1.19.1", "pytest>=9.0.2", "pytest-asyncio>=1.3.0", "pytest-cov>=7.0.0", "ruff>=0.14.10", "fastmcp[code-mode]>=3.4.2,<4", "hypothesis>=6.152.3", "respx>=0.23.1",]

--- a/src/amazon_ads_mcp/metering/__init__.py
+++ b/src/amazon_ads_mcp/metering/__init__.py
@@ -1,0 +1,15 @@
+"""Amazon Ads MCP metering integration (Task 22).
+
+Wires the ``mcp-outbound-metering`` producer package (billing repo,
+``packages/python/mcp_outbound_metering``) into this server so every real
+Amazon Ads API call is metered while internal/auth traffic stays untouched.
+
+This ``__init__`` intentionally imports nothing eagerly: every submodule is
+safe to import on its own, and ``compat.py`` is the only one that ever
+touches ``mcp_outbound_metering`` -- keeping this package's import surface
+inert avoids any accidental import-time coupling (or import cycle) between
+e.g. ``adapter.py`` (imported from ``utils/http_client.py``) and
+``context.py`` (which imports back from ``utils/http_client.py``).
+"""
+
+from __future__ import annotations

--- a/src/amazon_ads_mcp/metering/adapter.py
+++ b/src/amazon_ads_mcp/metering/adapter.py
@@ -1,0 +1,80 @@
+"""The transport install seam (Task 22 ruling #3).
+
+``install_metered_transport`` is called from exactly one place in
+production code: ``AuthenticatedClient.__init__``
+(``utils/http_client.py``), right after ``super().__init__(...)``, wrapping
+``self._transport``. httpx 0.28.1's ``AsyncClient`` dispatches every
+request through ``self._transport`` unless ``self._mounts`` has a matching
+pattern (verified: no construction path anywhere in this repo passes
+``mounts=``, so ``_mounts`` is always empty and every request routes
+through ``self._transport``) -- wrapping ``self._transport`` in
+``__init__`` therefore covers every way an ``AuthenticatedClient`` (or a
+subclass, e.g. ``ResilientAuthenticatedClient``, whose ``__init__`` calls
+``super().__init__(*args, **kwargs)``) is ever constructed:
+``ServerBuilder._setup_http_client()`` (one shared instance for all OpenAPI
+mounts) and ``HTTPClientManager.get_client(client_class=AuthenticatedClient)``
+(the secondary instance ``tools/profile_listing.py`` uses). Neither
+construction path -- nor anything else in this repo -- ever needs to call
+this function directly.
+
+This module deliberately imports NOTHING from ``mcp_outbound_metering``,
+directly or via ``compat`` -- it only needs a duck-typed ``runtime`` object
+exposing ``wrap_transport(...)`` (whatever :func:`set_metering_runtime`
+was given), so it stays importable, at module scope, from
+``utils/http_client.py`` on every Python version, including <3.12 where
+metering is entirely unavailable. This is also why this module never
+imports ``metering.context``/``metering.normalizer`` at module scope: both
+of those import back from ``utils.http_client`` (``context.py`` needs
+``get_routing_state``), and importing them eagerly here would create an
+import cycle with ``utils/http_client.py`` (which imports this module at
+ITS module scope). The lazy import inside :func:`install_metered_transport`
+below only ever runs once ``utils.http_client`` has finished executing (a
+client is being constructed), by which point the cycle is moot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+__all__ = ["get_metering_runtime", "install_metered_transport", "set_metering_runtime"]
+
+_runtime: Optional[Any] = None
+
+
+def set_metering_runtime(runtime: Optional[Any]) -> None:
+    """Set (or clear, with ``None``) the process-wide active metering
+    runtime. Called only by the lifespan wiring (``metering.lifespan``)
+    and by tests -- never by application/tool code."""
+    global _runtime
+    _runtime = runtime
+
+
+def get_metering_runtime() -> Optional[Any]:
+    """The active metering runtime, or ``None`` when metering is disabled,
+    unavailable, or not yet started."""
+    return _runtime
+
+
+def install_metered_transport(inner: httpx.AsyncBaseTransport) -> httpx.AsyncBaseTransport:
+    """Wrap ``inner`` with the metered transport when a runtime is active;
+    otherwise return ``inner`` UNCHANGED. Never wraps ``_mounts`` -- this
+    function only ever touches the transport instance handed to it
+    (``self._transport`` in ``AuthenticatedClient.__init__``), and
+    ``_mounts`` is unused throughout this repo (see the module docstring).
+    """
+    runtime = get_metering_runtime()
+    if runtime is None:
+        return inner
+
+    from .context import tenant_key, usage_context
+    from .normalizer import normalize_path
+
+    return runtime.wrap_transport(
+        inner,
+        context_provider=usage_context,
+        tenant_key_provider=tenant_key,
+        path_normalizer=normalize_path,
+        template_resolver=None,
+    )

--- a/src/amazon_ads_mcp/metering/adapter.py
+++ b/src/amazon_ads_mcp/metering/adapter.py
@@ -1,21 +1,38 @@
-"""The transport install seam (Task 22 ruling #3).
+"""The transport install seam (Task 22 ruling #3; fix round 1, CRITICAL +
+IMPORTANT).
 
-``install_metered_transport`` is called from exactly one place in
-production code: ``AuthenticatedClient.__init__``
-(``utils/http_client.py``), right after ``super().__init__(...)``, wrapping
-``self._transport``. httpx 0.28.1's ``AsyncClient`` dispatches every
-request through ``self._transport`` unless ``self._mounts`` has a matching
-pattern (verified: no construction path anywhere in this repo passes
-``mounts=``, so ``_mounts`` is always empty and every request routes
-through ``self._transport``) -- wrapping ``self._transport`` in
-``__init__`` therefore covers every way an ``AuthenticatedClient`` (or a
-subclass, e.g. ``ResilientAuthenticatedClient``, whose ``__init__`` calls
-``super().__init__(*args, **kwargs)``) is ever constructed:
-``ServerBuilder._setup_http_client()`` (one shared instance for all OpenAPI
-mounts) and ``HTTPClientManager.get_client(client_class=AuthenticatedClient)``
-(the secondary instance ``tools/profile_listing.py`` uses). Neither
-construction path -- nor anything else in this repo -- ever needs to call
-this function directly.
+``install_metered_transport`` is called from exactly two places, both in
+``AuthenticatedClient.__init__`` (``utils/http_client.py``), right after
+``super().__init__(...)``: once on ``self._transport``, and once for every
+populated value in ``self._mounts`` (proxy transports httpx auto-installs
+from ``HTTP_PROXY``/``HTTPS_PROXY``/``ALL_PROXY`` when ``trust_env=True``,
+httpx's default here -- verified no construction path in this repo
+overrides ``trust_env``). httpx 0.28.1's ``Client._transport_for_url``
+checks ``_mounts`` for a matching pattern FIRST and only falls back to
+``self._transport`` when none matches, so a populated, unwrapped mount
+would bypass metering entirely regardless of what wraps
+``self._transport`` alone. Together these two calls cover every way an
+``AuthenticatedClient`` (or a subclass, e.g. ``ResilientAuthenticatedClient``,
+whose ``__init__`` calls ``super().__init__(*args, **kwargs)``) is ever
+constructed: ``ServerBuilder._setup_http_client()`` (one shared instance
+for all OpenAPI mounts) and ``HTTPClientManager.get_client(client_class=
+AuthenticatedClient)`` (the secondary instance ``tools/profile_listing.py``
+uses). Neither construction path -- nor anything else in this repo --
+ever needs to call this function directly.
+
+Fix round 1, CRITICAL: ``ServerBuilder.build()`` (which constructs the
+shared ``AuthenticatedClient`` via ``_setup_http_client()``) runs BEFORE
+``mcp.run()`` ever triggers ``server_lifespan()``, where
+``start_metering()`` actually installs the active runtime. The original
+design made the wrap decision ONCE, at ``__init__`` time -- for the
+shared client, that decision permanently captured ``runtime=None``, so
+the shared client (used for every OpenAPI-mounted tool call) was NEVER
+metered in the real running server, no matter how long it ran afterward.
+``LazyMeteredTransport`` fixes this by deferring the decision to REQUEST
+time: it is installed unconditionally at construction, and every
+``handle_async_request`` call freshly consults :func:`get_metering_runtime`
+-- construction order relative to ``start_metering()``/``stop_metering()``
+no longer matters at all.
 
 This module deliberately imports NOTHING from ``mcp_outbound_metering``,
 directly or via ``compat`` -- it only needs a duck-typed ``runtime`` object
@@ -27,9 +44,10 @@ imports ``metering.context``/``metering.normalizer`` at module scope: both
 of those import back from ``utils.http_client`` (``context.py`` needs
 ``get_routing_state``), and importing them eagerly here would create an
 import cycle with ``utils/http_client.py`` (which imports this module at
-ITS module scope). The lazy import inside :func:`install_metered_transport`
-below only ever runs once ``utils.http_client`` has finished executing (a
-client is being constructed), by which point the cycle is moot.
+ITS module scope). The lazy import inside ``LazyMeteredTransport``'s own
+``handle_async_request`` below only ever runs once ``utils.http_client``
+has finished executing (a request is being sent), by which point the
+cycle is moot.
 """
 
 from __future__ import annotations
@@ -38,7 +56,12 @@ from typing import Any, Optional
 
 import httpx
 
-__all__ = ["get_metering_runtime", "install_metered_transport", "set_metering_runtime"]
+__all__ = [
+    "LazyMeteredTransport",
+    "get_metering_runtime",
+    "install_metered_transport",
+    "set_metering_runtime",
+]
 
 _runtime: Optional[Any] = None
 
@@ -57,24 +80,77 @@ def get_metering_runtime() -> Optional[Any]:
     return _runtime
 
 
-def install_metered_transport(inner: httpx.AsyncBaseTransport) -> httpx.AsyncBaseTransport:
-    """Wrap ``inner`` with the metered transport when a runtime is active;
-    otherwise return ``inner`` UNCHANGED. Never wraps ``_mounts`` -- this
-    function only ever touches the transport instance handed to it
-    (``self._transport`` in ``AuthenticatedClient.__init__``), and
-    ``_mounts`` is unused throughout this repo (see the module docstring).
+class LazyMeteredTransport(httpx.AsyncBaseTransport):
+    """Wraps ``inner`` and defers the metering-wrap decision to REQUEST
+    time (fix round 1, CRITICAL) instead of construction time.
+
+    Every ``handle_async_request`` call freshly reads
+    :func:`get_metering_runtime`:
+
+    - ``None`` (no active runtime -- metering disabled, unavailable, not
+      yet started, or already stopped): delegates straight to ``inner``,
+      unmetered.
+    - An active runtime: builds the real wrapped transport via
+      ``runtime.wrap_transport(inner, ...)`` ONCE per distinct runtime
+      object (cached by identity in ``self._cached_runtime``/
+      ``self._cached_transport`` -- rebuilt only if the active runtime
+      object itself changes, e.g. after a stop/restart cycle installs a
+      new instance) and delegates to that.
+
+    This makes the wrap fully independent of construction order: a client
+    built before ``start_metering()`` ever runs (the real boot order --
+    ``ServerBuilder.build()`` constructs the shared client before
+    ``mcp.run()`` triggers ``server_lifespan()``) still gets metered once
+    a runtime activates, and correctly reverts to unmetered pass-through
+    if the runtime later deactivates (``stop_metering()``) -- with no
+    errors either way.
+
+    ``aclose()`` closes ``inner`` exactly once. It never routes through
+    the cached wrapped transport's own ``aclose()`` -- that would also
+    close ``inner``, just redundantly (``MeteredAsyncTransport.aclose()``
+    is itself idempotent, but there is no need to rely on that here, and
+    the cached transport may be stale/absent if no runtime was ever
+    active).
     """
-    runtime = get_metering_runtime()
-    if runtime is None:
-        return inner
 
-    from .context import tenant_key, usage_context
-    from .normalizer import normalize_path
+    def __init__(self, inner: httpx.AsyncBaseTransport) -> None:
+        self._inner = inner
+        self._cached_runtime: Optional[Any] = None
+        self._cached_transport: Optional[httpx.AsyncBaseTransport] = None
+        self._closed = False
 
-    return runtime.wrap_transport(
-        inner,
-        context_provider=usage_context,
-        tenant_key_provider=tenant_key,
-        path_normalizer=normalize_path,
-        template_resolver=None,
-    )
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        runtime = get_metering_runtime()
+        if runtime is None:
+            return await self._inner.handle_async_request(request)
+
+        if runtime is not self._cached_runtime:
+            from .context import tenant_key, usage_context
+            from .normalizer import normalize_path
+
+            self._cached_transport = runtime.wrap_transport(
+                self._inner,
+                context_provider=usage_context,
+                tenant_key_provider=tenant_key,
+                path_normalizer=normalize_path,
+                template_resolver=None,
+            )
+            self._cached_runtime = runtime
+
+        assert self._cached_transport is not None
+        return await self._cached_transport.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._inner.aclose()
+
+
+def install_metered_transport(inner: httpx.AsyncBaseTransport) -> httpx.AsyncBaseTransport:
+    """Always wrap ``inner`` in a :class:`LazyMeteredTransport` (fix round
+    1, CRITICAL) -- the actual metering decision is deferred to request
+    time inside that wrapper, never made here at construction time. Safe
+    to call for both ``self._transport`` and any populated
+    ``self._mounts`` value (fix round 1, IMPORTANT)."""
+    return LazyMeteredTransport(inner)

--- a/src/amazon_ads_mcp/metering/attribution.py
+++ b/src/amazon_ads_mcp/metering/attribution.py
@@ -1,0 +1,83 @@
+"""``tool_name`` attribution for metering dimensions (Task 22 ruling #5).
+
+No ``tool-name`` ContextVar existed anywhere in this repo before this
+module (verified repo fact) -- every OTHER per-request ContextVar lives
+next to the state it tracks (``_REGION_OVERRIDE_VAR``/``_ROUTING_STATE_VAR``
+in ``utils/http_client.py``, the auth ContextVars in
+``auth/session_state.py``). ``tool_name`` is metering-specific (it exists
+only to become a ``usage_context()`` dimension), so it lives here instead.
+
+Two call sites set/reset it around a dispatch, both using
+:func:`tool_name_scope` for identical semantics:
+
+1. :class:`ToolAttributionMiddleware`, registered in
+   ``ServerBuilder._setup_middleware`` alongside the server's other
+   middleware -- covers the ordinary ``on_call_tool`` dispatch path.
+2. ``server/code_mode.py``'s ``bridged_call_tool`` -- the Code Mode sandbox
+   bridge that calls tools *without* going through the server's middleware
+   chain (design §7.1's attribution gap). Without this second call site,
+   every Code Mode tool call would silently lose the ``tool_name``
+   dimension even though the underlying HTTP call is metered exactly the
+   same as an ordinary call.
+
+Per ruling #5: "Missing attribution must never suppress an event (it's
+just a dimension)" -- this module never raises, and a call made outside
+either scope simply sees ``get_tool_name() is None``, which
+``metering.context.usage_context()`` reflects as a ``None`` dimension
+value, not a dropped event (`MeteredAsyncTransport`'s own failure
+isolation guarantees that independently -- see the producer's
+``transport.py`` module docstring).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Awaitable, Callable, Iterator, Optional
+
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+__all__ = ["ToolAttributionMiddleware", "get_tool_name", "tool_name_scope"]
+
+_tool_name_var: ContextVar[Optional[str]] = ContextVar("metering_tool_name", default=None)
+
+
+def get_tool_name() -> Optional[str]:
+    """The tool name attributed to the current async context, or ``None``
+    when no :func:`tool_name_scope` is active (e.g. a request outside any
+    tool call, or attribution genuinely missing)."""
+    return _tool_name_var.get()
+
+
+@contextmanager
+def tool_name_scope(name: Optional[str]) -> Iterator[None]:
+    """Set ``tool_name`` for the duration of the ``with`` block and reset
+    it in a ``finally`` -- used identically by
+    :class:`ToolAttributionMiddleware` and ``code_mode.py``'s
+    ``bridged_call_tool`` so both attribution call sites share one
+    set/reset implementation."""
+    token = _tool_name_var.set(name)
+    try:
+        yield
+    finally:
+        _tool_name_var.reset(token)
+
+
+class ToolAttributionMiddleware(Middleware):
+    """FastMCP middleware: sets ``tool_name`` for the duration of an
+    ordinary ``on_call_tool`` dispatch. Registered in
+    ``ServerBuilder._setup_middleware`` alongside the server's existing
+    middleware -- position in the chain does not matter for correctness
+    (every middleware wraps ``call_next``, and the eventual HTTP call
+    happens deep inside that chain, still within the same async context),
+    only that it wraps the dispatch at all.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext,
+        call_next: Callable[[MiddlewareContext], Awaitable[Any]],
+    ) -> Any:
+        tool_name = getattr(context.message, "name", None) if context.message else None
+        with tool_name_scope(tool_name):
+            return await call_next(context)

--- a/src/amazon_ads_mcp/metering/compat.py
+++ b/src/amazon_ads_mcp/metering/compat.py
@@ -1,0 +1,79 @@
+"""<3.12 compatibility guard for the metering integration (Task 22 ruling #2).
+
+``mcp-outbound-metering`` requires Python>=3.12 (see its own
+``pyproject.toml``), while this repository's floor is 3.10 (CI matrix
+3.10-3.12). The dependency itself is therefore declared conditionally
+(``pyproject.toml``: ``mcp-outbound-metering[verify] ; python_version >=
+'3.12'``) -- on 3.10/3.11 it is simply never installed.
+
+Every other module under ``amazon_ads_mcp.metering`` that needs a real
+``mcp_outbound_metering`` symbol imports it from HERE, never directly --
+so a <3.12 interpreter (or one where the package failed to install for any
+other reason) never even attempts the import. On <3.12 or import failure,
+metering support is a loud no-op: :data:`METERING_AVAILABLE` is ``False``,
+every re-exported symbol is ``None``, and the rest of the server behaves
+exactly as it did before this integration existed. This module itself must
+ALWAYS be importable, on every supported Python version -- that is the
+entire point of the guard.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "METERING_AVAILABLE",
+    "METERING_MIN_PYTHON",
+    "MeteringConfigError",
+    "MeteringError",
+    "MeteringRuntime",
+    "warn_unsupported",
+]
+
+# mcp-outbound-metering's own floor (packages/python/mcp_outbound_metering/
+# pyproject.toml: requires-python = ">=3.12").
+METERING_MIN_PYTHON = (3, 12)
+
+METERING_AVAILABLE: bool
+MeteringRuntime: Optional[Any] = None
+MeteringConfigError: Optional[Any] = None
+MeteringError: Optional[Any] = None
+
+if sys.version_info >= METERING_MIN_PYTHON:
+    try:
+        from mcp_outbound_metering.errors import (
+            MeteringConfigError as _MeteringConfigError,
+        )
+        from mcp_outbound_metering.errors import MeteringError as _MeteringError
+        from mcp_outbound_metering.runtime import MeteringRuntime as _MeteringRuntime
+    except ImportError:
+        METERING_AVAILABLE = False
+    else:
+        METERING_AVAILABLE = True
+        MeteringRuntime = _MeteringRuntime
+        MeteringConfigError = _MeteringConfigError
+        MeteringError = _MeteringError
+else:
+    METERING_AVAILABLE = False
+
+
+def warn_unsupported() -> None:
+    """Log the loud no-op warning (ruling #2). Callers (the lifespan
+    wiring in ``metering.lifespan``) invoke this only when
+    ``METERING_ENABLED`` is truthy but :data:`METERING_AVAILABLE` is
+    ``False`` -- an unset/false ``METERING_ENABLED`` never logs anything,
+    since that is ordinary, expected "metering not configured" behavior on
+    any Python version.
+    """
+    running = ".".join(str(part) for part in sys.version_info[:3])
+    logger.warning(
+        "metering disabled: requires Python>=%s (running %s) or "
+        "mcp-outbound-metering is not installed -- METERING_ENABLED is set "
+        "but no usage events will be recorded",
+        ".".join(str(p) for p in METERING_MIN_PYTHON),
+        running,
+    )

--- a/src/amazon_ads_mcp/metering/compat.py
+++ b/src/amazon_ads_mcp/metering/compat.py
@@ -2,9 +2,14 @@
 
 ``mcp-outbound-metering`` requires Python>=3.12 (see its own
 ``pyproject.toml``), while this repository's floor is 3.10 (CI matrix
-3.10-3.12). The dependency itself is therefore declared conditionally
-(``pyproject.toml``: ``mcp-outbound-metering[verify] ; python_version >=
-'3.12'``) -- on 3.10/3.11 it is simply never installed.
+3.10-3.12). It is ALSO a private git dependency (fix round 2, deployment
+gap #2), so it lives behind the optional ``metering`` extra
+(``pyproject.toml``: ``[project.optional-dependencies] metering =
+["mcp-outbound-metering ; python_version >= '3.12'"]``) rather than
+``[project.dependencies]`` -- a plain install/sync never touches it, on
+any Python version. Installing with ``pip install
+'amazon-ads-mcp[metering]'`` (or ``uv sync --extra metering``) on 3.12+
+is required for :data:`METERING_AVAILABLE` to be ``True``.
 
 Every other module under ``amazon_ads_mcp.metering`` that needs a real
 ``mcp_outbound_metering`` symbol imports it from HERE, never directly --
@@ -67,13 +72,17 @@ def warn_unsupported() -> None:
     ``METERING_ENABLED`` is truthy but :data:`METERING_AVAILABLE` is
     ``False`` -- an unset/false ``METERING_ENABLED`` never logs anything,
     since that is ordinary, expected "metering not configured" behavior on
-    any Python version.
+    any Python version. Names the exact install command (fix round 2,
+    deployment gap #2: the package lives behind the optional "metering"
+    extra, not a base dependency) so an operator debugging a failed/
+    disabled startup knows precisely what to run.
     """
     running = ".".join(str(part) for part in sys.version_info[:3])
     logger.warning(
         "metering disabled: requires Python>=%s (running %s) or "
-        "mcp-outbound-metering is not installed -- METERING_ENABLED is set "
-        "but no usage events will be recorded",
+        "mcp-outbound-metering is not installed -- install with "
+        "pip/uv install 'amazon-ads-mcp[metering]' (Python>=3.12 required). "
+        "METERING_ENABLED is set but no usage events will be recorded",
         ".".join(str(p) for p in METERING_MIN_PYTHON),
         running,
     )

--- a/src/amazon_ads_mcp/metering/config.py
+++ b/src/amazon_ads_mcp/metering/config.py
@@ -1,0 +1,73 @@
+"""Resolves ``metering.yaml``'s path across dev and packaged deployments
+(fix round 2, deployment gap #1).
+
+Docker/wheel deployments never carry the repo-root ``metering.yaml`` --
+the Docker runtime image copies the venv + ``dist/openapi`` + the
+entrypoint into ``/app``, not a repo checkout (see ``Dockerfile``), and a
+wheel install (``pip install 'amazon-ads-mcp[metering]'``) only ships
+files that are actually packaged. Resolution order:
+
+1. ``METERING_CONFIG`` env var, if set -- an explicit operator override,
+   used verbatim (interpreted relative to CWD if not absolute, exactly
+   like every other bare ``Path(...)`` use in this codebase).
+2. ``./metering.yaml`` relative to CWD, if that file exists -- dev
+   convenience: running from a repo checkout finds the tracked
+   repo-root file with zero configuration.
+3. The packaged copy at ``amazon_ads_mcp/metering/metering.yaml``,
+   resolved via :mod:`importlib.resources` -- works from a wheel install
+   AND from a Docker image's site-packages, independent of CWD. This
+   copy is byte-identical to the repo-root file (see
+   ``tests/metering/test_packaged_config.py``'s drift guard, which fails
+   loudly if the two ever diverge).
+
+This module has no dependency on ``mcp_outbound_metering`` -- only on
+``importlib.resources`` (stdlib) -- so it stays importable on every
+Python version, same as ``normalizer.py``/``context.py``.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import Mapping
+
+__all__ = ["resolve_config_path"]
+
+_CONFIG_FILENAME = "metering.yaml"
+_PACKAGE = "amazon_ads_mcp.metering"
+
+
+def resolve_config_path(env: Mapping[str, str]) -> Path:
+    """Resolve ``metering.yaml``'s path per the module docstring's
+    3-step order. Read-only -- never writes, never creates a file."""
+    explicit = env.get("METERING_CONFIG")
+    if explicit:
+        return Path(explicit)
+
+    cwd_relative = Path(_CONFIG_FILENAME)
+    if cwd_relative.is_file():
+        return cwd_relative
+
+    return _packaged_config_path()
+
+
+def _packaged_config_path() -> Path:
+    """The packaged ``metering.yaml``, as a real filesystem
+    :class:`~pathlib.Path`.
+
+    :func:`importlib.resources.as_file` is a no-op for a normal (non-zip)
+    package install -- the file is already a real path on disk, and
+    nothing is deleted when the context manager exits. That covers every
+    deployment shape this project actually uses: a ``uv sync``'d Docker
+    image and a plain ``pip``/``uv``-installed wheel both extract into
+    site-packages as regular files, never a zipped/zipimport-style
+    install. This function reads ``metering.yaml`` exactly once per
+    process, synchronously, at startup (via
+    ``MeteringRuntime.from_config``), so eagerly resolving and returning
+    the path here -- rather than requiring every caller to hold the
+    ``as_file`` context manager open for the life of the process -- is
+    safe for this deployment model.
+    """
+    ref = resources.files(_PACKAGE).joinpath(_CONFIG_FILENAME)
+    with resources.as_file(ref) as path:
+        return path

--- a/src/amazon_ads_mcp/metering/conformance.py
+++ b/src/amazon_ads_mcp/metering/conformance.py
@@ -1,0 +1,172 @@
+"""Conformance harness factory (Task 22 ruling #8) -- the scaffold's
+generated harness factory, adapted into this repo's real modules.
+
+Two things drive this module:
+
+1. ``tests/metering/test_conformance.py`` (``ProducerConformanceSuite``
+   subclass, zero overrides) -- ``uv run pytest tests/metering -q``.
+2. ``mcp-metering verify --config metering.yaml --harness
+   amazon_ads_mcp.metering.conformance:create_conformance_harness`` --
+   the CI ``metering`` job (ruling #9).
+
+Both require the integration guide's §4 CI environment block to already
+be exported in the real process environment (this module reads
+``os.environ`` directly, like the scaffold's own template -- it does not
+hardcode conformance-only values the way ``examples/httpx`` does, since
+this is the real adapter a real deployment also loads through
+``metering.lifespan.start_metering()``). ``tests/metering/conftest.py``
+exports that same block via ``monkeypatch`` so the pytest path is
+self-sufficient locally too.
+
+Builds the REAL ``AuthenticatedClient`` construction path (design
+§3.5.5): ``make_provider_client`` constructs an actual
+``AuthenticatedClient`` after ``set_metering_runtime`` has installed this
+harness's runtime, so ``AuthenticatedClient.__init__``'s own
+``install_metered_transport`` call (``utils/http_client.py``) is what
+wraps the transport here -- never a direct call to
+``runtime.wrap_transport`` from this module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+from . import compat
+from .adapter import set_metering_runtime
+
+__all__ = ["create_conformance_harness"]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_PATH = _REPO_ROOT / "metering.yaml"
+
+_EXPECTED_DIMENSIONS = frozenset({"identity_id", "profile_id", "region", "auth_method", "tool_name"})
+
+
+class _ConformanceAuthManager:
+    """Minimal `AuthenticatedClient`-compatible auth manager: enough for
+    `_inject_headers` to succeed (a valid Authorization + ClientId pair)
+    without a real provider, credential store, or network endpoint.
+    `provider = None` keeps the identity-routing branch off, so requests
+    are never rewritten away from whatever host the suite's upstream
+    double is registered under."""
+
+    provider = None
+
+    async def get_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": "Bearer conformance-test-token",
+            "Amazon-Advertising-API-ClientId": "conformance-test-client-id",
+        }
+
+
+class _RaisingTelemetryMirror:
+    """A `TelemetryMirror` that violates its own never-raise contract on
+    purpose -- installed only when `options.break_mirror` is `True`
+    (`ProducerConformanceSuite`'s mirror-isolation scenario)."""
+
+    def __init__(self) -> None:
+        self.failure_count = 0
+
+    def emit_usage_event(self, event: Dict[str, Any]) -> None:
+        self.failure_count += 1
+        raise RuntimeError("mcp-metering conformance: mirror double violates its contract on purpose")
+
+    def close(self) -> None:
+        return None
+
+
+class _Harness:
+    """The `ConformanceHarness` this module exposes -- matches the
+    `Protocol` in `mcp_outbound_metering.conformance.harness`
+    structurally, no inheritance needed."""
+
+    def __init__(self, runtime: Any) -> None:
+        self.runtime = runtime
+        self.allowed_host = os.environ.get("METERING_UPSTREAM_HOSTS", "").split(",")[0]
+        self.disallowed_lookalike_host = f"{self.allowed_host}.evil.invalid"
+        self.expected_dimensions = _EXPECTED_DIMENSIONS
+
+    async def make_provider_client(self, upstream: httpx.AsyncBaseTransport) -> httpx.AsyncClient:
+        """The REAL construction path: `AuthenticatedClient.__init__`
+        (`utils/http_client.py`) calls `install_metered_transport`,
+        which reads the module-level runtime `create_conformance_harness`
+        already installed via `set_metering_runtime`."""
+        from ..utils.http_client import AuthenticatedClient
+
+        return AuthenticatedClient(transport=upstream, auth_manager=_ConformanceAuthManager())
+
+    async def invoke_internal_only(self) -> None:
+        """One representative internal/excluded operation: constructing
+        (and closing) a plain `httpx.AsyncClient` -- the exact shape
+        every OAuth/OpenBridge/Kuudo provider client takes in this repo
+        (verified repo fact) -- which structurally never touches the
+        metered transport regardless of whether a runtime is active."""
+        client = httpx.AsyncClient()
+        await client.aclose()
+
+    async def aclose(self) -> None:
+        set_metering_runtime(None)
+        await self.runtime.aclose()
+
+
+def _env(path: Path) -> Dict[str, str]:
+    """Environment overlay for `MeteringRuntime.from_config`, read from
+    the REAL process environment -- no value is ever hardcoded here
+    (design §3.3: "never writes secrets into tracked files"). The
+    integration guide's §4 CI environment block supplies every
+    `METERING_*` value this needs when running `mcp-metering verify` or
+    `pytest tests/metering`; only per-source-id/per-instance defaults are
+    filled in here via `setdefault`."""
+    overlay = dict(os.environ)
+    overlay.setdefault("METERING_SOURCE_ID", "amazon_ads_mcp")
+    overlay.setdefault("METERING_UPSTREAM_SERVICE", "amazon_ads")
+    overlay.setdefault("METERING_OUTBOX_PATH", str(path / "outbox.db"))
+    overlay.setdefault(
+        "METERING_DIMENSIONS", ",".join(sorted(_EXPECTED_DIMENSIONS))
+    )
+    return overlay
+
+
+async def create_conformance_harness(path: Path, options: Any) -> Any:
+    """Factory for `mcp_outbound_metering.conformance.ProducerConformanceSuite`
+    (design §3.5.5), wired the SAME way `metering.lifespan.start_metering`
+    constructs the runtime in production
+    (`MeteringRuntime.from_config` -> `await start()` ->
+    `set_metering_runtime`). `options` is a
+    `mcp_outbound_metering.conformance.HarnessOptions` -- typed `Any` here
+    so importing this module never requires metering to be available at
+    import time, only when this factory actually runs.
+    """
+    if not compat.METERING_AVAILABLE:
+        raise RuntimeError(
+            "metering conformance harness requires Python>=3.12 and "
+            "mcp-outbound-metering installed"
+        )
+
+    env = _env(path)
+    env.update(options.env_overrides)
+
+    exporter_transport = options.ingest_transport
+    if exporter_transport is None:
+        # A safe, non-networked default -- never fall back to a real
+        # network call here.
+        exporter_transport = httpx.MockTransport(lambda request: httpx.Response(200))
+
+    mirror: Optional[Any] = _RaisingTelemetryMirror() if options.break_mirror else None
+
+    runtime = compat.MeteringRuntime.from_config(
+        _CONFIG_PATH,
+        env,
+        exporter_transport=exporter_transport,
+        mirror=mirror,
+        flusher_now=options.flusher_now,
+        flusher_sleep=options.flusher_sleep,
+    )
+    await runtime.start()
+    set_metering_runtime(runtime)
+
+    return _Harness(runtime)

--- a/src/amazon_ads_mcp/metering/conformance.py
+++ b/src/amazon_ads_mcp/metering/conformance.py
@@ -37,11 +37,9 @@ import httpx
 
 from . import compat
 from .adapter import set_metering_runtime
+from .config import resolve_config_path
 
 __all__ = ["create_conformance_harness"]
-
-_REPO_ROOT = Path(__file__).resolve().parents[3]
-_CONFIG_PATH = _REPO_ROOT / "metering.yaml"
 
 _EXPECTED_DIMENSIONS = frozenset({"identity_id", "profile_id", "region", "auth_method", "tool_name"})
 
@@ -159,7 +157,7 @@ async def create_conformance_harness(path: Path, options: Any) -> Any:
     mirror: Optional[Any] = _RaisingTelemetryMirror() if options.break_mirror else None
 
     runtime = compat.MeteringRuntime.from_config(
-        _CONFIG_PATH,
+        resolve_config_path(env),
         env,
         exporter_transport=exporter_transport,
         mirror=mirror,

--- a/src/amazon_ads_mcp/metering/context.py
+++ b/src/amazon_ads_mcp/metering/context.py
@@ -1,0 +1,92 @@
+"""Usage-context and tenant-key providers (Task 22 ruling #4).
+
+Passed to ``MeteringRuntime.wrap_transport(context_provider=usage_context,
+tenant_key_provider=tenant_key, ...)`` (see ``metering/adapter.py``).
+Dimension allowlist (must match ``metering.yaml``'s ``dimensions:`` list
+and ``METERING_DIMENSIONS``): ``identity_id``, ``profile_id``, ``region``,
+``auth_method``, ``tool_name``. ``operation_id``/``api_group`` are
+intentionally omitted in v1 -- there is no HTTP-layer source for either
+without a ``template_resolver`` (post-v1, design §3.2).
+
+Like ``normalizer.py``, this module has no dependency on
+``mcp_outbound_metering`` -- only on this repo's own auth/session-state
+modules -- so it stays importable on every supported Python version.
+Every field lookup below is independently guarded: a failure resolving
+one dimension (e.g. no auth manager configured yet) must never blank out
+the others, and per ruling #4/§8.3, missing attribution must never
+suppress the usage event itself -- ``MeteredAsyncTransport``'s own
+failure isolation guarantees that independently even if this whole
+function raised, but the per-field guards here keep as much real
+attribution as possible instead of an all-or-nothing ``{}``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from ..auth.manager import get_auth_manager
+from ..auth.session_state import get_active_identity
+from .attribution import get_tool_name
+
+__all__ = ["tenant_key", "usage_context"]
+
+
+def _identity_id() -> Optional[str]:
+    identity = get_active_identity()
+    return identity.id if identity is not None else None
+
+
+def _profile_id() -> Optional[str]:
+    try:
+        return get_auth_manager().get_active_profile_id()
+    except Exception:
+        return None
+
+
+def _region() -> Optional[str]:
+    try:
+        # Imported lazily: `utils.http_client` imports `metering.adapter`
+        # at module scope, and `metering.adapter` imports THIS module
+        # lazily (inside a function) for exactly this reason -- see
+        # `adapter.py`'s module docstring. Importing `get_routing_state`
+        # at this module's own top level would be fine in isolation, but
+        # keeping it lazy here too avoids ever depending on import order
+        # between `utils.http_client` and `metering.context`.
+        from ..utils.http_client import get_routing_state
+
+        routing_state = get_routing_state()
+        return routing_state.get("region") if routing_state else None
+    except Exception:
+        return None
+
+
+def _auth_method() -> Optional[str]:
+    try:
+        provider = getattr(get_auth_manager(), "provider", None)
+        return getattr(provider, "provider_type", None) if provider is not None else None
+    except Exception:
+        return None
+
+
+def usage_context() -> Dict[str, Optional[str]]:
+    """Opaque analytics dimensions for the current call (design §3.2,
+    ruling #4): ``identity_id`` from ``get_active_identity()``,
+    ``profile_id`` from the active auth manager (if exposed by session
+    state), ``region`` from ``get_routing_state()`` (``None`` when
+    unset), ``auth_method`` from the active provider's ``provider_type``,
+    and ``tool_name`` from the attribution ContextVar
+    (``metering.attribution``)."""
+    return {
+        "identity_id": _identity_id(),
+        "profile_id": _profile_id(),
+        "region": _region(),
+        "auth_method": _auth_method(),
+        "tool_name": get_tool_name(),
+    }
+
+
+def tenant_key() -> Optional[str]:
+    """Opaque tenant lookup key (design §3.2, ruling #4): the active
+    identity's id -- the same value ``usage_context()`` reports as
+    ``identity_id``."""
+    return _identity_id()

--- a/src/amazon_ads_mcp/metering/lifespan.py
+++ b/src/amazon_ads_mcp/metering/lifespan.py
@@ -1,0 +1,129 @@
+"""Lifespan wiring: start/stop the metering runtime, and the `/health`
+payload merge (Task 22 ruling #8).
+
+Kept separate from `server/mcp_server.py`'s `server_lifespan()` so the
+gating/strict-failure logic is unit-testable without a running FastMCP
+server (see `tests/metering/test_lifespan.py`). `server_lifespan()` calls
+`start_metering()` in its existing startup `try` block (so a raised
+exception is already caught, logged, and re-raised by that block's
+`except Exception as e: logger.error(...); raise`) and `stop_metering()`
+in its `finally` block, BEFORE `http_client_manager.close_all()`.
+
+Billing-critical policy (design §7.3: "startup validates before accepting
+traffic"): `METERING_ENABLED` is the master switch.
+
+- Unset, empty, or exactly ``"false"`` (case-insensitive): metering is not
+  requested at all -- a silent no-op, the overwhelmingly common case on
+  every Python version and in every deployment that hasn't opted in.
+- Any OTHER non-empty value ("true", "TRUE", "1", a typo): an ATTEMPT is
+  made to start metering, so a genuine misconfiguration is logged loudly
+  rather than silently ignored.
+- Whether a startup FAILURE (Python<3.12, package unavailable, invalid
+  config, etc.) is fatal depends on whether the value is STRICTLY "true"
+  (case-insensitive exact match, matching
+  `mcp_outbound_metering.policy`'s own `_parse_bool` convention): if
+  strict, `start_metering()` re-raises (server refuses to accept traffic
+  without metering); otherwise it logs and returns `None` (server
+  continues without metering).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+from . import compat
+from .adapter import get_metering_runtime, set_metering_runtime
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["metering_health_payload", "start_metering", "stop_metering"]
+
+_DEFAULT_CONFIG_PATH = "metering.yaml"
+
+
+def _is_truthy(raw: Optional[str]) -> bool:
+    if raw is None:
+        return False
+    return raw.strip().lower() not in ("", "false")
+
+
+def _is_strict(raw: Optional[str]) -> bool:
+    return raw is not None and raw.strip().lower() == "true"
+
+
+async def start_metering(env: Optional[Mapping[str, str]] = None) -> Optional[Any]:
+    """Attempt to construct and start the metering runtime per
+    ``METERING_ENABLED`` (read from ``env``, defaulting to the real
+    process environment). Returns the started runtime (already installed
+    via :func:`set_metering_runtime`) or ``None`` when metering was not
+    requested, or could not start non-fatally. Raises when
+    ``METERING_ENABLED`` is strictly ``"true"`` and startup fails for any
+    reason.
+    """
+    source = env if env is not None else os.environ
+    raw = source.get("METERING_ENABLED")
+
+    if not _is_truthy(raw):
+        return None
+
+    strict = _is_strict(raw)
+
+    if not compat.METERING_AVAILABLE:
+        compat.warn_unsupported()
+        if strict:
+            raise RuntimeError(
+                "METERING_ENABLED=true but metering is unavailable (requires "
+                "Python>=3.12 and mcp-outbound-metering installed); refusing "
+                "to start without metering (design §7.3)"
+            )
+        return None
+
+    config_path = source.get("METERING_CONFIG", _DEFAULT_CONFIG_PATH)
+    try:
+        runtime = compat.MeteringRuntime.from_config(config_path, source)
+        await runtime.start()
+    except Exception:
+        logger.exception(
+            "metering startup failed (config=%s, strict=%s)", config_path, strict
+        )
+        if strict:
+            raise
+        return None
+
+    set_metering_runtime(runtime)
+    logger.info("metering enabled and started (config=%s)", config_path)
+    return runtime
+
+
+async def stop_metering() -> None:
+    """Idempotent and safe to call even when metering was never started.
+    Clears the module-level runtime accessor FIRST, then closes the
+    runtime (ruling #8's ordering) -- both steps happen before the
+    caller's own `http_client_manager.close_all()`. Never raises: a
+    close failure is logged, not propagated, so metering shutdown can
+    never block the rest of graceful shutdown.
+    """
+    runtime = get_metering_runtime()
+    if runtime is None:
+        return
+    set_metering_runtime(None)
+    try:
+        await runtime.aclose()
+    except Exception:
+        logger.exception("metering shutdown failed")
+
+
+def metering_health_payload() -> Optional[dict]:
+    """``runtime.health()`` when a runtime is active, else ``None`` --
+    merged into the server's ``/health`` payload under ``"metering"``
+    (`ServerBuilder._setup_health_check`)."""
+    runtime = get_metering_runtime()
+    if runtime is None:
+        return None
+    try:
+        return runtime.health()
+    except Exception:
+        logger.exception("metering health check failed")
+        return {"status": "error"}

--- a/src/amazon_ads_mcp/metering/lifespan.py
+++ b/src/amazon_ads_mcp/metering/lifespan.py
@@ -35,12 +35,11 @@ from typing import Any, Mapping, Optional
 
 from . import compat
 from .adapter import get_metering_runtime, set_metering_runtime
+from .config import resolve_config_path
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["metering_health_payload", "start_metering", "stop_metering"]
-
-_DEFAULT_CONFIG_PATH = "metering.yaml"
 
 
 def _is_truthy(raw: Optional[str]) -> bool:
@@ -75,12 +74,13 @@ async def start_metering(env: Optional[Mapping[str, str]] = None) -> Optional[An
         if strict:
             raise RuntimeError(
                 "METERING_ENABLED=true but metering is unavailable (requires "
-                "Python>=3.12 and mcp-outbound-metering installed); refusing "
-                "to start without metering (design §7.3)"
+                "Python>=3.12 and the optional 'metering' extra installed -- "
+                "run pip/uv install 'amazon-ads-mcp[metering]'); refusing to "
+                "start without metering (design §7.3)"
             )
         return None
 
-    config_path = source.get("METERING_CONFIG", _DEFAULT_CONFIG_PATH)
+    config_path = resolve_config_path(source)
     try:
         runtime = compat.MeteringRuntime.from_config(config_path, source)
         await runtime.start()

--- a/src/amazon_ads_mcp/metering/metering.yaml
+++ b/src/amazon_ads_mcp/metering/metering.yaml
@@ -1,0 +1,50 @@
+# Adapter config for amazon_ads_mcp (Task 22), generated per the
+# `mcp-metering install` scaffold and hand-adapted into
+# src/amazon_ads_mcp/metering/ (design §3.5.2). Non-secret: every *_env
+# key below names an environment variable this file never reads a value
+# for. Credentials, account mappings, sink routes, and pricing never
+# belong here (design §3.5.3).
+schema_version: 1
+source_id: amazon_ads_mcp
+provider:
+  service: amazon_ads
+  # DEPLOYMENT NOTE (fix round 1, MINOR): the host match is EXACT, never
+  # a suffix/wildcard, and Amazon Ads is a 3-region API
+  # (RegionConfig.API_HOSTS: na/eu/fe, utils/region_config.py).
+  # METERING_UPSTREAM_HOSTS must list ALL THREE regional hosts before
+  # enabling in production --
+  #   advertising-api.amazon.com, advertising-api-eu.amazon.com,
+  #   advertising-api-fe.amazon.com
+  # -- plus the sandbox "-test" variants
+  # (advertising-api-test.amazon.com, advertising-api-eu-test.amazon.com,
+  # advertising-api-fe-test.amazon.com) if AMAZON_ADS_SANDBOX_MODE is
+  # ever used. With disallowed_host_action: reject (below), listing only
+  # the NA host breaks EU/FE traffic outright the moment an
+  # identity/marketplace routes a request to a regional endpoint that
+  # isn't allowlisted -- every such call raises DisallowedHostError
+  # instead of reaching Amazon.
+  exact_hosts_env: METERING_UPSTREAM_HOSTS
+  disallowed_host_action: reject
+# Declarative only -- nothing in mcp-outbound-metering reads
+# context_provider/path_normalizer off this file at runtime; they are
+# wired by hand in src/amazon_ads_mcp/metering/adapter.py via
+# MeteringRuntime.wrap_transport() (design §3.5.4). If either of these
+# modules is ever relocated, update these strings too -- they are plain
+# strings naming an importable module path, not a live Python reference.
+transport:
+  adapter: httpx
+  context_provider: amazon_ads_mcp.metering.context:usage_context
+  path_normalizer: amazon_ads_mcp.metering.normalizer:normalize_path
+# Allowlist (Task 22 ruling #4). operation_id/api_group are intentionally
+# omitted in v1 -- no HTTP-layer source exists for either without a
+# template_resolver (post-v1, design §3.2).
+dimensions:
+  - identity_id
+  - profile_id
+  - region
+  - auth_method
+  - tool_name
+outbox:
+  mode: sqlite
+  path_env: METERING_OUTBOX_PATH
+  max_bytes_env: METERING_OUTBOX_MAX_BYTES

--- a/src/amazon_ads_mcp/metering/normalizer.py
+++ b/src/amazon_ads_mcp/metering/normalizer.py
@@ -1,0 +1,57 @@
+"""Low-cardinality path normalizer for the metered transport (Task 22
+ruling #7).
+
+Passed to ``MeteringRuntime.wrap_transport(..., path_normalizer=...)``
+(see ``metering/adapter.py``). Never touched on a Python version where
+metering is unavailable (:mod:`amazon_ads_mcp.metering.compat`) -- this
+module has no dependency on ``mcp_outbound_metering`` itself, only on
+``httpx`` (already a core dependency of this project), so it stays
+importable on every supported Python version.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+
+__all__ = ["normalize_path"]
+
+# A path segment made up entirely of digits, e.g. the "42" in
+# "/v2/campaigns/42".
+_NUMERIC_SEGMENT_RE = re.compile(r"^\d+$")
+
+# Amazon Ads entity-id shape: a leading "A" followed by 8+ uppercase
+# letters/digits, e.g. profile/entity ids like "ENTITY1AZ2BCD3EF".
+_AMAZON_ENTITY_ID_RE = re.compile(r"^A[A-Z0-9]{8,}$")
+
+# Canonical UUID (with dashes), case-insensitive.
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _is_high_cardinality(segment: str) -> bool:
+    """True for a path segment that should collapse to ``{id}`` -- pure
+    digits, an Amazon entity-id shape, or a UUID. Stable segments (e.g.
+    ``v2``, ``profiles``, ``campaigns``) never match any of these and pass
+    through unchanged, per design (``/v2/profiles`` stays itself)."""
+    if not segment:
+        return False
+    return bool(
+        _NUMERIC_SEGMENT_RE.match(segment)
+        or _AMAZON_ENTITY_ID_RE.match(segment)
+        or _UUID_RE.match(segment)
+    )
+
+
+def normalize_path(request: httpx.Request) -> str:
+    """Collapse high-cardinality path segments (numeric ids, Amazon
+    entity-id shapes, UUIDs) to ``{id}`` so per-record identifiers never
+    become distinct, high-cardinality ``url.path`` dimension values.
+    Operates on ``request.url.path`` only -- httpx never includes the
+    query string there, so this normalizer can never leak one (design
+    ruling #7)."""
+    segments = request.url.path.split("/")
+    normalized = ["{id}" if _is_high_cardinality(segment) else segment for segment in segments]
+    return "/".join(normalized)

--- a/src/amazon_ads_mcp/server/code_mode.py
+++ b/src/amazon_ads_mcp/server/code_mode.py
@@ -484,31 +484,42 @@ class AuthBridgingSandboxProvider:
                 # fire regardless of which call surface the LLM picked.
                 from .sidecar_middleware import apply_sidecar_input_transforms
 
+                # Task 22 (metering, design §7.1): this bridge is the
+                # documented attribution gap -- it dispatches
+                # original_call_tool WITHOUT going through the server's
+                # middleware chain, so ToolAttributionMiddleware never
+                # runs for it. Set the SAME tool_name ContextVar directly
+                # around the nested dispatch so metering events for Code
+                # Mode tool calls carry the same tool_name dimension an
+                # ordinary call would.
+                from ..metering.attribution import tool_name_scope
+
                 async with call_lock:
                     await hydrate_auth_from_mcp_session(
                         parent_ctx, logger_instance=logger
                     )
-                    try:
-                        rewritten = await apply_sidecar_input_transforms(
-                            name, params or {}
-                        )
+                    with tool_name_scope(name):
                         try:
-                            return await original_call_tool(name, rewritten)
-                        except Exception as exc:
-                            # Translate via the v1 envelope-aware helper so
-                            # ToolErrors carrying envelope JSON surface in the
-                            # sandbox as ``RuntimeError("<error_kind>: <summary>")``
-                            # rather than nesting the full envelope JSON
-                            # inside a generic RuntimeError. Non-envelope
-                            # exceptions keep the legacy
-                            # ``RuntimeError("<OriginalType>: <message>")`` form.
-                            # See ``EXECUTE_DESCRIPTION`` and the contract at
-                            # openbridge-mcp/CONTRACT.md.
-                            raise translate_to_sandbox_runtime_error(exc) from None
-                    finally:
-                        await persist_auth_to_mcp_session(
-                            parent_ctx, logger_instance=logger
-                        )
+                            rewritten = await apply_sidecar_input_transforms(
+                                name, params or {}
+                            )
+                            try:
+                                return await original_call_tool(name, rewritten)
+                            except Exception as exc:
+                                # Translate via the v1 envelope-aware helper so
+                                # ToolErrors carrying envelope JSON surface in the
+                                # sandbox as ``RuntimeError("<error_kind>: <summary>")``
+                                # rather than nesting the full envelope JSON
+                                # inside a generic RuntimeError. Non-envelope
+                                # exceptions keep the legacy
+                                # ``RuntimeError("<OriginalType>: <message>")`` form.
+                                # See ``EXECUTE_DESCRIPTION`` and the contract at
+                                # openbridge-mcp/CONTRACT.md.
+                                raise translate_to_sandbox_runtime_error(exc) from None
+                        finally:
+                            await persist_auth_to_mcp_session(
+                                parent_ctx, logger_instance=logger
+                            )
 
             wrapped_functions["call_tool"] = bridged_call_tool
 

--- a/src/amazon_ads_mcp/server/mcp_server.py
+++ b/src/amazon_ads_mcp/server/mcp_server.py
@@ -85,6 +85,18 @@ async def server_lifespan(server: Any) -> AsyncIterator[None]:
             logger.warning("No auth provider configured")
 
         logger.info("Server lifespan: Startup complete")
+
+        # Task 22 (metering): start before accepting traffic (design
+        # §3.5.4 step 4, §7.3). A startup failure here is caught by this
+        # same try/except -- when METERING_ENABLED is strictly "true",
+        # start_metering() re-raises and this block's own re-raise below
+        # fails server startup entirely (billing-critical: design §7.3
+        # "startup validates before accepting traffic"). Any looser
+        # truthy-but-not-strict value logs loudly and returns None
+        # instead of raising, so the server still starts.
+        from ..metering.lifespan import start_metering
+
+        await start_metering()
     except Exception as e:
         logger.error(f"Server lifespan: Startup error: {e}")
         raise
@@ -100,6 +112,19 @@ async def server_lifespan(server: Any) -> AsyncIterator[None]:
             logger.debug("Server lifespan: Cleanup already done by fallback handler")
         else:
             logger.info("Server lifespan: Shutting down...")
+
+            # Task 22 (metering): stop BEFORE closing HTTP clients (design
+            # ruling #8's ordering) -- stop_metering() itself never
+            # raises (internal aclose() failures are logged, not
+            # propagated), but this is wrapped the same defensive way as
+            # every other shutdown step here.
+            try:
+                from ..metering.lifespan import stop_metering
+
+                await stop_metering()
+                logger.info("Metering stopped")
+            except Exception as e:
+                logger.error(f"Error stopping metering: {e}")
 
             # Close HTTP clients
             try:

--- a/src/amazon_ads_mcp/server/server_builder.py
+++ b/src/amazon_ads_mcp/server/server_builder.py
@@ -300,6 +300,19 @@ class ServerBuilder:
             "(per-identity QAA result cache)"
         )
 
+        # Task 22 (metering): attribute the tool_name dimension for the
+        # ordinary on_call_tool dispatch path. Position in the chain does
+        # not affect correctness (every middleware here wraps call_next,
+        # and the eventual metered HTTP call happens deep inside that same
+        # async context) -- see metering/attribution.py's module docstring.
+        # The Code Mode sandbox bridge (server/code_mode.py's
+        # bridged_call_tool) sets the SAME ContextVar directly, since that
+        # path bypasses this middleware chain entirely (design §7.1).
+        from ..metering.attribution import ToolAttributionMiddleware
+
+        middleware_list.append(ToolAttributionMiddleware())
+        logger.info("Added ToolAttributionMiddleware (metering tool_name dimension)")
+
         # Error callback for logging
         def error_callback(error: Exception, context=None) -> None:
             logger.error(f"Tool execution error: {type(error).__name__}: {error}")
@@ -1169,13 +1182,24 @@ class ServerBuilder:
         built_at = os.getenv("AMAZON_ADS_MCP_BUILD_TIME", "unknown")
 
         def _health_payload() -> dict:
-            return {
+            payload = {
                 "status": "healthy",
                 "service": "amazon-ads-mcp",
                 "version": package_version,
                 "git_sha": git_sha,
                 "built_at": built_at,
             }
+            # Task 22 (metering ruling #8): merge runtime.health() under
+            # "metering" when a runtime is active. metering_health_payload()
+            # returns None (key omitted entirely) when metering was never
+            # started -- e.g. every deployment that hasn't opted in, and
+            # every 3.10/3.11 process.
+            from ..metering.lifespan import metering_health_payload
+
+            metering = metering_health_payload()
+            if metering is not None:
+                payload["metering"] = metering
+            return payload
 
         @self.server.custom_route("/health", methods=["GET"])
         async def health_check(request: Request) -> JSONResponse:

--- a/src/amazon_ads_mcp/utils/http/resilient_client.py
+++ b/src/amazon_ads_mcp/utils/http/resilient_client.py
@@ -5,6 +5,7 @@ all resilience patterns recommended by Amazon for API interactions.
 """
 
 import logging
+import uuid
 from typing import Any, Dict
 
 import httpx
@@ -103,9 +104,27 @@ class ResilientAuthenticatedClient(AuthenticatedClient):
                 logger.error(f"Rate limit timeout for {endpoint}")
                 raise Exception(f"Rate limit acquisition timeout for {endpoint}")
 
+        # Metering retry attribution (Task 22 ruling #6): one
+        # logical_request_id per logical send(), reused across every
+        # retry attempt of this SAME request object; retry_attempt is
+        # zero-based (0 = first attempt). Set unconditionally -- this
+        # module has no dependency on metering being enabled/available,
+        # the metered transport (if any is wrapping self._transport)
+        # simply reads request.extensions["metering"] when present and
+        # ignores it otherwise. The plain (non-resilient)
+        # AuthenticatedClient.send() path sends no such extension, which
+        # is correct: it has no retry loop to attribute.
+        logical_request_id = str(uuid.uuid4())
+        attempt_counter = {"n": 0}
+
         # Create wrapped send function for retry decorator
         @self.retry_decorator
         async def send_with_retry():
+            request.extensions["metering"] = {
+                "logical_request_id": logical_request_id,
+                "retry_attempt": attempt_counter["n"],
+            }
+            attempt_counter["n"] += 1
             return await super(ResilientAuthenticatedClient, self).send(
                 request, **kwargs
             )

--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -132,14 +132,26 @@ class AuthenticatedClient(httpx.AsyncClient):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        # Task 22 (metering): wrap the transport httpx just constructed for
-        # us, IFF a metering runtime is active -- returns it unchanged
-        # otherwise. This is the ONE seam covering every construction path
-        # for this class and every subclass (e.g. ResilientAuthenticatedClient,
-        # whose __init__ calls super().__init__(*args, **kwargs)): every
-        # request sent through this client dispatches via self._transport
-        # (httpx 0.28.1; self._mounts is unused everywhere in this repo).
+        # Task 22 (metering; fix round 1, CRITICAL + IMPORTANT): install a
+        # LazyMeteredTransport unconditionally on self._transport AND on
+        # every populated self._mounts value. This is the ONE seam
+        # covering every construction path for this class and every
+        # subclass (e.g. ResilientAuthenticatedClient, whose __init__
+        # calls super().__init__(*args, **kwargs)): httpx 0.28.1 checks
+        # self._mounts for a matching pattern before falling back to
+        # self._transport, and self._mounts is auto-populated from
+        # HTTP_PROXY/HTTPS_PROXY/ALL_PROXY when trust_env=True (httpx's
+        # default here, left unchanged -- product behavior). The wrap
+        # decision itself is deferred to REQUEST time
+        # (LazyMeteredTransport consults get_metering_runtime() on every
+        # call), so it no longer matters whether a metering runtime is
+        # active yet at __init__ time -- only whether one is active when
+        # a request is actually sent.
         self._transport = install_metered_transport(self._transport)
+        self._mounts = {
+            pattern: (install_metered_transport(mount) if mount is not None else None)
+            for pattern, mount in self._mounts.items()
+        }
         self.auth_manager = auth_manager
         self.media_registry: Optional[MediaTypeRegistry] = media_registry
         self.header_resolver: HeaderNameResolver = (

--- a/src/amazon_ads_mcp/utils/http_client.py
+++ b/src/amazon_ads_mcp/utils/http_client.py
@@ -29,6 +29,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 import httpx
 
 from ..config.settings import Settings
+from ..metering.adapter import install_metered_transport
 from ..utils.export_content_type_resolver import (
     resolve_download_accept_headers,
 )
@@ -131,6 +132,14 @@ class AuthenticatedClient(httpx.AsyncClient):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        # Task 22 (metering): wrap the transport httpx just constructed for
+        # us, IFF a metering runtime is active -- returns it unchanged
+        # otherwise. This is the ONE seam covering every construction path
+        # for this class and every subclass (e.g. ResilientAuthenticatedClient,
+        # whose __init__ calls super().__init__(*args, **kwargs)): every
+        # request sent through this client dispatches via self._transport
+        # (httpx 0.28.1; self._mounts is unused everywhere in this repo).
+        self._transport = install_metered_transport(self._transport)
         self.auth_manager = auth_manager
         self.media_registry: Optional[MediaTypeRegistry] = media_registry
         self.header_resolver: HeaderNameResolver = (

--- a/tests/metering/_support.py
+++ b/tests/metering/_support.py
@@ -1,0 +1,128 @@
+"""Shared test support for tests/metering/ (Task 22).
+
+Not a test module itself (leading underscore keeps pytest from collecting
+it). Every module importing this one is skipif-guarded to Python>=3.12, so
+importing ``mcp_outbound_metering`` directly here -- rather than through
+``amazon_ads_mcp.metering.compat`` -- is safe: this module is never
+reached on <3.12.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+import httpx
+from mcp_outbound_metering.runtime import MeteringRuntime
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "metering.yaml"
+
+ALLOWED_HOST = "advertising-api.amazon.com"
+DIMENSIONS = "identity_id,profile_id,region,auth_method,tool_name"
+
+
+def base_env(tmp_path: Path, *, hosts: str = ALLOWED_HOST) -> dict:
+    """Conformance-only fake values (never a real credential/endpoint),
+    mirroring the guide's §4 CI environment block and
+    examples/httpx/example_adapter.py's ``_base_env``."""
+    return {
+        "METERING_ENABLED": "true",
+        "METERING_SOURCE_ID": "amazon_ads_mcp",
+        "METERING_ENDPOINT": "https://ingest.example-metering.test/v1/usage/batches",
+        "METERING_DEPLOYMENT_ID": "test-deployment",
+        "METERING_INSTANCE_ID": "test-instance",
+        "METERING_UPSTREAM_SERVICE": "amazon_ads",
+        "METERING_UPSTREAM_HOSTS": hosts,
+        "METERING_KEY_ID": "test-key-id",
+        "METERING_HMAC_SECRET": "test-hmac-secret-not-real",
+        "METERING_OUTBOX_MODE": "sqlite",
+        "METERING_OUTBOX_PATH": str(tmp_path / "outbox.db"),
+        "METERING_OUTBOX_MAX_BYTES": "10000000",
+        "METERING_DIMENSIONS": DIMENSIONS,
+        "METERING_OTEL_MIRROR": "false",
+        "METERING_BATCH_SIZE": "1",
+    }
+
+
+async def build_runtime(
+    tmp_path: Path,
+    *,
+    ingest: Optional[httpx.AsyncBaseTransport] = None,
+    env_overrides: Optional[Mapping[str, str]] = None,
+    hosts: str = ALLOWED_HOST,
+) -> MeteringRuntime:
+    """A started `MeteringRuntime` wired to the repo's real metering.yaml,
+    over a scripted (never real-network) ingest transport. Caller owns
+    `await runtime.aclose()`."""
+    env = base_env(tmp_path, hosts=hosts)
+    if env_overrides:
+        env.update(env_overrides)
+    exporter_transport = ingest or httpx.MockTransport(lambda request: httpx.Response(200))
+    runtime = MeteringRuntime.from_config(CONFIG_PATH, env, exporter_transport=exporter_transport)
+    await runtime.start()
+    return runtime
+
+
+class RecordingIngestTransport(httpx.AsyncBaseTransport):
+    """A fake ingest endpoint that records every batch it receives and
+    answers `200` by default. Exposes an event-driven wait
+    (`wait_for_event_count`) instead of a fixed sleep, mirroring
+    `mcp_outbound_metering.conformance.suite`'s own `_RecordingTransport`
+    -- the background flusher task delivers batches asynchronously, so
+    tests must wait for arrival rather than guess a sleep duration.
+    """
+
+    def __init__(
+        self, responder: Optional[Callable[[int, httpx.Request], httpx.Response]] = None
+    ) -> None:
+        self.requests: list[httpx.Request] = []
+        self._responder = responder
+        self._arrived = asyncio.Event()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        index = len(self.requests)
+        self.requests.append(request)
+        self._arrived.set()
+        if self._responder is not None:
+            return self._responder(index, request)
+        return httpx.Response(200)
+
+    def events(self) -> list[dict]:
+        flat: list[dict] = []
+        for request in self.requests:
+            flat.extend(json.loads(request.content))
+        return flat
+
+    async def wait_for_event_count(self, n: int, *, timeout: float = 5.0) -> list[dict]:
+        async def _wait() -> None:
+            while len(self.events()) < n:
+                self._arrived.clear()
+                if len(self.events()) >= n:
+                    return
+                await self._arrived.wait()
+
+        await asyncio.wait_for(_wait(), timeout=timeout)
+        return self.events()
+
+
+class FakeAuthManager:
+    """The smallest `AuthenticatedClient`-compatible auth manager double:
+    provides just enough for `_inject_headers` to succeed (a valid
+    Authorization + ClientId header pair) without touching any real
+    provider, credential store, or network endpoint. `provider=None`
+    keeps `_inject_headers`'s identity-routing branch off (`hasattr(None,
+    ...)` is False), so requests are never rewritten away from the
+    `allowed_host` a test constructed its upstream against.
+    """
+
+    provider = None
+
+    async def get_headers(self) -> dict:
+        return {
+            "Authorization": "Bearer conformance-test-token",
+            "Amazon-Advertising-API-ClientId": "conformance-test-client-id",
+        }

--- a/tests/metering/conftest.py
+++ b/tests/metering/conftest.py
@@ -13,15 +13,58 @@ Deliberately excludes `METERING_OUTBOX_PATH` (the guide's own CI block
 doesn't set it either) -- `metering.conformance._env`'s `setdefault` then
 keeps each test's own `tmp_path`-scoped outbox path, preserving isolation
 between tests.
+
+Fix round 3, collection-safety gate
+------------------------------------
+`mcp-outbound-metering` now lives behind the optional `metering` extra
+(fix round 2) -- it is ALSO absent on a 3.12 interpreter that never ran
+`uv sync --extra metering`, exactly the `smoke` and `wheel-smoke` CI
+jobs, which sync on Python 3.12 but never request the extra. Before this
+gate, every `tests/metering/*.py` module's own `if sys.version_info >=
+(3, 12): import mcp_outbound_metering...` guard evaluated the version
+check as satisfied (3.12) and executed the import anyway, dying with a
+collection-time `ModuleNotFoundError` -- CI logs showed exactly this:
+"ImportError while importing test module .../test_attribution_event_flow.py
+... ModuleNotFoundError: No module named 'mcp_outbound_metering'".
+
+The fix below runs `pytest.importorskip("mcp_outbound_metering")` at
+MODULE level, gated to `sys.version_info >= (3, 12)` ONLY -- this is the
+critical detail. pytest always loads a directory's conftest.py before
+collecting (importing) any test module inside it, so a module-level skip
+here cleanly skips collection of the ENTIRE `tests/metering/` subtree as
+one unit, before any test module's own top-level import ever runs.
+
+The version guard on the `importorskip` itself matters because
+`mcp_outbound_metering` is ALSO never installed on <3.12 (by design --
+its own floor is 3.12) -- an unconditional `importorskip` here would
+blanket-skip the whole directory on 3.10 too, silently swallowing the
+~24 tests that are specifically written to run on EVERY Python version
+(test_compat_guard.py, test_normalizer.py, test_attribution.py,
+test_context.py, test_code_mode_attribution.py, test_lifespan_guard.py,
+and several in test_packaged_config.py -- each documents in its own
+module docstring why it deliberately isn't skipif-guarded). Gating this
+check to 3.12+ leaves <3.12 collection completely untouched: those
+version-independent tests keep running, and every version-gated test
+module's own `pytestmark = pytest.mark.skipif(sys.version_info < (3,
+12), ...)` keeps giving the clearer, more specific "why" for the 3.10
+floor -- this conftest gate exists ONLY to catch "3.12+, but the package
+genuinely isn't installed," the one case no existing guard covered.
 """
 
 from __future__ import annotations
 
 import asyncio
+import sys
 
 import pytest
 
-from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime
+if sys.version_info >= (3, 12):
+    pytest.importorskip(
+        "mcp_outbound_metering",
+        reason="metering extra not installed (uv sync --extra metering)",
+    )
+
+from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime  # noqa: E402
 
 _CI_ENV_BLOCK = {
     "METERING_ENABLED": "true",

--- a/tests/metering/conftest.py
+++ b/tests/metering/conftest.py
@@ -1,0 +1,69 @@
+"""Fixtures for tests/metering/.
+
+Only `test_conformance.py` (via `amazon_ads_mcp.metering.conformance`)
+reads `os.environ` directly for its policy -- every other test module
+under `tests/metering/` builds its own explicit env dict (see
+`_support.base_env`) and never depends on this fixture. Mirrors the
+integration guide's §4 "CI environment" block (conformance-only fakes,
+never a real credential/endpoint) so `uv run pytest tests/metering -q`
+is self-sufficient locally, the same values the CI `metering` job (Task
+22 ruling #9) exports before running the identical command.
+
+Deliberately excludes `METERING_OUTBOX_PATH` (the guide's own CI block
+doesn't set it either) -- `metering.conformance._env`'s `setdefault` then
+keeps each test's own `tmp_path`-scoped outbox path, preserving isolation
+between tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime
+
+_CI_ENV_BLOCK = {
+    "METERING_ENABLED": "true",
+    "METERING_UPSTREAM_HOSTS": "advertising-api.amazon.com",
+    "METERING_UPSTREAM_SERVICE": "amazon_ads",
+    "METERING_ENDPOINT": "https://ingest.example-metering.test/v1/usage/batches",
+    "METERING_DEPLOYMENT_ID": "ci",
+    "METERING_INSTANCE_ID": "ci-1",
+    "METERING_KEY_ID": "ci-key-placeholder",
+    "METERING_HMAC_SECRET": "ci-secret-placeholder",
+    "METERING_OUTBOX_MAX_BYTES": "10000000",
+}
+
+
+@pytest.fixture(autouse=True)
+def _conformance_ci_env(monkeypatch):
+    for key, value in _CI_ENV_BLOCK.items():
+        monkeypatch.setenv(key, value)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_metering_runtime_after_test():
+    """Safety net (found the hard way: an earlier test in this file that
+    asserted-and-failed left `set_metering_runtime()`'s module-level
+    global still pointing at a real, started `MeteringRuntime` -- which
+    then silently wrapped `AuthenticatedClient` construction in
+    UNRELATED test files later in the same pytest session, e.g.
+    `tests/unit/test_authenticated_client.py`). Every `tests/metering/`
+    test that sets an active runtime already cleans up in its own
+    `finally` block on the happy path; this fixture guarantees the
+    module-level global is back to `None` (and the runtime closed) even
+    when a test fails before reaching its own cleanup, so a bug or
+    assertion failure in ONE test can never leak metering state into
+    another test file.
+    """
+    yield
+    runtime = get_metering_runtime()
+    if runtime is None:
+        return
+    set_metering_runtime(None)
+    try:
+        asyncio.run(runtime.aclose())
+    except Exception:
+        pass

--- a/tests/metering/test_attribution.py
+++ b/tests/metering/test_attribution.py
@@ -1,0 +1,111 @@
+"""Unit tests for the tool_name attribution ContextVar + middleware (Task 22
+ruling #5).
+
+Not skipif-guarded: ``amazon_ads_mcp.metering.attribution`` has no
+dependency on ``mcp_outbound_metering`` (only ``fastmcp``, already a core
+dependency), so -- same rationale as ``test_compat_guard.py`` and
+``test_normalizer.py`` -- it is tested on every supported Python version.
+The §8.3 "middleware sets/resets tool_name" and "code_mode bridged path
+sets it too" bullets are covered end-to-end (through the real
+``AuthenticatedClient``/transport stack) in ``test_conformance.py`` and
+``test_code_mode_attribution.py``; this module covers the primitive in
+isolation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from amazon_ads_mcp.metering.attribution import (
+    ToolAttributionMiddleware,
+    get_tool_name,
+    tool_name_scope,
+)
+
+
+def test_no_scope_means_no_tool_name() -> None:
+    assert get_tool_name() is None
+
+
+def test_tool_name_scope_sets_and_resets() -> None:
+    assert get_tool_name() is None
+    with tool_name_scope("get_profiles"):
+        assert get_tool_name() == "get_profiles"
+    assert get_tool_name() is None
+
+
+def test_tool_name_scope_resets_on_exception() -> None:
+    with pytest.raises(RuntimeError):
+        with tool_name_scope("boom_tool"):
+            assert get_tool_name() == "boom_tool"
+            raise RuntimeError("boom")
+    assert get_tool_name() is None
+
+
+def test_tool_name_scope_nests_and_restores_outer_value() -> None:
+    with tool_name_scope("outer_tool"):
+        assert get_tool_name() == "outer_tool"
+        with tool_name_scope("inner_tool"):
+            assert get_tool_name() == "inner_tool"
+        assert get_tool_name() == "outer_tool"
+    assert get_tool_name() is None
+
+
+def _make_context(tool_name: str | None) -> SimpleNamespace:
+    message = SimpleNamespace(name=tool_name) if tool_name is not None else None
+    return SimpleNamespace(message=message)
+
+
+@pytest.mark.parametrize("_unused", [1])
+def test_middleware_sets_tool_name_during_call_next(_unused) -> None:
+    import asyncio
+
+    middleware = ToolAttributionMiddleware()
+    observed = {}
+
+    async def call_next(context):
+        observed["tool_name"] = get_tool_name()
+        return "ok"
+
+    async def scenario():
+        result = await middleware.on_call_tool(_make_context("search_profiles"), call_next)
+        assert result == "ok"
+
+    asyncio.run(scenario())
+    assert observed["tool_name"] == "search_profiles"
+    assert get_tool_name() is None  # reset after on_call_tool returns
+
+
+def test_middleware_resets_even_when_call_next_raises() -> None:
+    import asyncio
+
+    middleware = ToolAttributionMiddleware()
+
+    async def call_next(context):
+        raise ValueError("downstream failure")
+
+    async def scenario():
+        with pytest.raises(ValueError):
+            await middleware.on_call_tool(_make_context("page_profiles"), call_next)
+
+    asyncio.run(scenario())
+    assert get_tool_name() is None
+
+
+def test_middleware_missing_message_name_is_none_not_a_crash() -> None:
+    import asyncio
+
+    middleware = ToolAttributionMiddleware()
+    observed = {}
+
+    async def call_next(context):
+        observed["tool_name"] = get_tool_name()
+        return "ok"
+
+    async def scenario():
+        await middleware.on_call_tool(_make_context(None), call_next)
+
+    asyncio.run(scenario())
+    assert observed["tool_name"] is None

--- a/tests/metering/test_attribution_event_flow.py
+++ b/tests/metering/test_attribution_event_flow.py
@@ -1,0 +1,165 @@
+"""§8.3 "Attribution", end-to-end through the real metering pipeline: the
+tool_name dimension flows from `ToolAttributionMiddleware`/`code_mode.py`'s
+bridge into the recorded usage event, missing attribution never suppresses
+the event, and ordinary vs Code Mode dispatch produce identical event
+counts (Task 22 ruling #5).
+
+`test_attribution.py` and `test_code_mode_attribution.py` cover the
+ContextVar/middleware/bridge primitives in isolation without a metering
+package dependency; this module drives the SAME primitives through a real
+`AuthenticatedClient` + `MeteringRuntime` to prove the dimension actually
+lands on a recorded event.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import set_metering_runtime
+    from amazon_ads_mcp.metering.attribution import ToolAttributionMiddleware
+    from amazon_ads_mcp.server.code_mode import create_auth_bridging_sandbox_provider
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
+
+
+def test_middleware_sets_tool_name_dimension_on_recorded_event(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            middleware = ToolAttributionMiddleware()
+
+            async def call_next(context):
+                upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+                client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+                try:
+                    return await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+                finally:
+                    await client.aclose()
+
+            context = SimpleNamespace(message=SimpleNamespace(name="search_profiles"))
+            response = await middleware.on_call_tool(context, call_next)
+            assert response.status_code == 200
+
+            events = await ingest.wait_for_event_count(1)
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        assert len(events) == 1
+        assert events[0]["data"]["dimensions"]["tool_name"] == "search_profiles"
+
+    asyncio.run(scenario())
+
+
+def test_missing_attribution_never_suppresses_the_event(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            # No tool_name_scope, no middleware -- an HTTP call made
+            # entirely outside any attribution scope.
+            upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+            client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+            try:
+                response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+                assert response.status_code == 200
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(1)
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        # The event was still emitted -- dimension absent, not the event.
+        assert len(events) == 1
+        assert events[0]["data"]["dimensions"].get("tool_name") is None
+
+    asyncio.run(scenario())
+
+
+class _DummyContext:
+    def __init__(self) -> None:
+        self.request_context = object()
+        self.state: dict = {}
+
+    async def get_state(self, key):
+        return self.state.get(key)
+
+    async def set_state(self, key, value):
+        self.state[key] = value
+
+
+def test_ordinary_and_code_mode_dispatch_produce_identical_event_counts(tmp_path) -> None:
+    """§8.3: "ordinary vs code-mode counts identical." Both paths make
+    exactly one metered HTTP call per tool invocation; Code Mode's bridge
+    must neither drop nor duplicate the resulting usage event relative to
+    the ordinary middleware path."""
+
+    async def make_one_metered_call() -> httpx.Response:
+        upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+        client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+        try:
+            return await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+        finally:
+            await client.aclose()
+
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            # Ordinary path: ToolAttributionMiddleware wraps a tool that
+            # makes one metered call.
+            middleware = ToolAttributionMiddleware()
+
+            async def ordinary_call_next(context):
+                return await make_one_metered_call()
+
+            ordinary_ctx = SimpleNamespace(message=SimpleNamespace(name="search_profiles"))
+            await middleware.on_call_tool(ordinary_ctx, ordinary_call_next)
+
+            # Code Mode path: the bridge wraps the SAME kind of nested
+            # call, via a stub sandbox, for the same tool name.
+            async def bridged_call_tool_target(name, params):
+                assert name == "search_profiles"
+                return await make_one_metered_call()
+
+            class _StubSandbox:
+                async def run(self, code, *, inputs=None, external_functions=None):
+                    return await external_functions["call_tool"]("search_profiles", {})
+
+            provider = create_auth_bridging_sandbox_provider(_StubSandbox())
+            ctx = _DummyContext()
+            with patch("amazon_ads_mcp.server.code_mode.get_context", return_value=ctx):
+                await provider.run(
+                    "noop",
+                    inputs={},
+                    external_functions={"call_tool": bridged_call_tool_target},
+                )
+
+            events = await ingest.wait_for_event_count(2)
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        assert len(events) == 2
+        tool_names = [e["data"]["dimensions"]["tool_name"] for e in events]
+        assert tool_names == ["search_profiles", "search_profiles"]
+
+    asyncio.run(scenario())

--- a/tests/metering/test_cli_verify_subprocess.py
+++ b/tests/metering/test_cli_verify_subprocess.py
@@ -1,0 +1,87 @@
+"""§8.3 "Conformance + verify" (second half): `mcp-metering verify` exits
+0 against the real harness, with the integration guide's §4 CI
+environment block values (Task 22 ruling #9). Runs the installed
+`mcp-metering` console script as a real subprocess -- the exact command
+the CI `metering` job runs -- so this test also proves the console script
+entry point itself resolves correctly in this repo's dependency closure,
+not just that the Python API works when imported in-process (already
+covered by `test_conformance.py`).
+
+3.12 only, same as every other `tests/metering/` module: `mcp-metering`
+is not installed at all on <3.12 (the dependency is conditional on
+`python_version >= '3.12'`), so `sys.executable` (unconditionally the
+CURRENT interpreter -- guaranteeing subprocess and pytest run under the
+same interpreter) simply wouldn't have the script on <3.12.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+REPO_ROOT = None
+if sys.version_info >= (3, 12):
+    from pathlib import Path
+
+    REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Integration guide §4's CI environment block (conformance-only fakes,
+# never a real credential/endpoint), adapted to this repo's provider
+# name/allowed host.
+_CI_ENV_BLOCK = {
+    "METERING_ENABLED": "true",
+    "METERING_UPSTREAM_HOSTS": "advertising-api.amazon.com",
+    "METERING_UPSTREAM_SERVICE": "amazon_ads",
+    "METERING_ENDPOINT": "https://ingest.example-metering.test/v1/usage/batches",
+    "METERING_DEPLOYMENT_ID": "ci",
+    "METERING_INSTANCE_ID": "ci-1",
+    "METERING_KEY_ID": "ci-key-placeholder",
+    "METERING_HMAC_SECRET": "ci-secret-placeholder",
+    "METERING_OUTBOX_MAX_BYTES": "10000000",
+}
+
+
+@pytest.mark.slow
+def test_mcp_metering_verify_exits_zero(tmp_path) -> None:
+    env = dict(os.environ)
+    env.update(_CI_ENV_BLOCK)
+    env["METERING_OUTBOX_PATH"] = str(tmp_path / "outbox.db")
+    json_path = tmp_path / "report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mcp_outbound_metering.cli",
+            "verify",
+            "--config",
+            "metering.yaml",
+            "--harness",
+            "amazon_ads_mcp.metering.conformance:create_conformance_harness",
+            "--skip-ingest",
+            "--json",
+            str(json_path),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"mcp-metering verify exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    report = json.loads(json_path.read_text())
+    assert report["summary"]["FAIL"] == 0
+    assert report["summary"]["PASS"] >= 11  # every suite scenario + config/policy/outbox

--- a/tests/metering/test_code_mode_attribution.py
+++ b/tests/metering/test_code_mode_attribution.py
@@ -1,0 +1,160 @@
+"""§8.3 "Attribution": the Code Mode sandbox bridge
+(`server/code_mode.py`'s `bridged_call_tool`) sets tool_name too --
+unit-tested here with a stub sandbox call, per the brief. This is the
+design §7.1 attribution gap: `bridged_call_tool` dispatches
+`original_call_tool` WITHOUT going through `ServerBuilder`'s middleware
+chain (so `ToolAttributionMiddleware`, tested in `test_attribution.py`,
+never runs for it) -- `code_mode.py` sets the SAME ContextVar directly
+instead.
+
+Not skipif-guarded: exercises `amazon_ads_mcp.server.code_mode` and
+`amazon_ads_mcp.metering.attribution`, neither of which depends on
+`mcp_outbound_metering` -- same rationale as `test_attribution.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from amazon_ads_mcp.auth.session_state import reset_all_session_state
+from amazon_ads_mcp.metering.attribution import get_tool_name
+from amazon_ads_mcp.server.code_mode import create_auth_bridging_sandbox_provider
+
+
+class _DummyContext:
+    """Minimal FastMCP-context double satisfying
+    `middleware.auth_session_bridge.has_auth_session` (needs `get_state`
+    and a non-None `request_context`) -- same shape as
+    `tests/unit/test_code_mode.py`'s own `DummyContext`."""
+
+    def __init__(self) -> None:
+        self.request_context = object()
+        self.state: dict = {}
+
+    async def get_state(self, key):
+        return self.state.get(key)
+
+    async def set_state(self, key, value):
+        self.state[key] = value
+
+
+class _StubSandbox:
+    """A stub sandbox: `.run()` just calls `external_functions["call_tool"]`
+    directly (whatever `AuthBridgingSandboxProvider.run` installed --
+    `bridged_call_tool` when a parent context is present, the original
+    otherwise) and returns whatever it returns."""
+
+    def __init__(self) -> None:
+        self.observed_tool_names: list = []
+
+    async def run(self, code, *, inputs=None, external_functions=None):
+        call_tool = external_functions["call_tool"]
+        result = await call_tool("search_profiles", {"query": "acme"})
+        self.observed_tool_names.append(get_tool_name())
+        return result
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    reset_all_session_state()
+    yield
+    reset_all_session_state()
+
+
+def test_bridged_call_tool_sets_tool_name_during_nested_dispatch() -> None:
+    observed_during_call = {}
+
+    async def fake_call_tool(name, params):
+        observed_during_call["tool_name"] = get_tool_name()
+        observed_during_call["name_arg"] = name
+        return {"ok": True}
+
+    sandbox = _StubSandbox()
+    provider = create_auth_bridging_sandbox_provider(sandbox)
+    ctx = _DummyContext()
+
+    async def scenario():
+        with patch("amazon_ads_mcp.server.code_mode.get_context", return_value=ctx):
+            return await provider.run(
+                "print('noop')",
+                inputs={},
+                external_functions={"call_tool": fake_call_tool},
+            )
+
+    result = asyncio.run(scenario())
+    assert result == {"ok": True}
+    # tool_name was set to the CALLED tool's name during the nested
+    # dispatch -- attributed to "search_profiles", not e.g. a code-mode
+    # meta-tool name.
+    assert observed_during_call["tool_name"] == "search_profiles"
+    assert observed_during_call["name_arg"] == "search_profiles"
+    # And reset afterward -- outside the bridge, nothing leaks.
+    assert get_tool_name() is None
+
+
+def test_bridged_call_tool_resets_tool_name_even_when_call_tool_raises() -> None:
+    async def failing_call_tool(name, params):
+        assert get_tool_name() == "search_profiles"
+        raise RuntimeError("boom")
+
+    sandbox_calls = {}
+
+    class _RaisingSandbox:
+        async def run(self, code, *, inputs=None, external_functions=None):
+            call_tool = external_functions["call_tool"]
+            try:
+                await call_tool("search_profiles", {})
+            except RuntimeError as exc:
+                sandbox_calls["caught"] = str(exc)
+            return None
+
+    provider = create_auth_bridging_sandbox_provider(_RaisingSandbox())
+    ctx = _DummyContext()
+
+    async def scenario():
+        with patch("amazon_ads_mcp.server.code_mode.get_context", return_value=ctx):
+            return await provider.run(
+                "print('noop')",
+                inputs={},
+                external_functions={"call_tool": failing_call_tool},
+            )
+
+    asyncio.run(scenario())
+    assert "caught" in sandbox_calls
+    assert get_tool_name() is None
+
+
+def test_without_parent_context_original_call_tool_is_used_unwrapped() -> None:
+    """No parent MCP context (get_context() raises, matching startup/
+    introspection paths per has_auth_session's own docstring) -> the
+    bridge never installs bridged_call_tool at all, so tool_name is never
+    set (missing attribution -- must not crash, per ruling #5)."""
+    observed = {}
+
+    async def fake_call_tool(name, params):
+        observed["tool_name"] = get_tool_name()
+        return {"ok": True}
+
+    class _PassthroughSandbox:
+        async def run(self, code, *, inputs=None, external_functions=None):
+            return await external_functions["call_tool"]("search_profiles", {})
+
+    provider = create_auth_bridging_sandbox_provider(_PassthroughSandbox())
+
+    async def scenario():
+        with patch(
+            "amazon_ads_mcp.server.code_mode.get_context",
+            side_effect=RuntimeError("no context"),
+        ):
+            return await provider.run(
+                "print('noop')",
+                inputs={},
+                external_functions={"call_tool": fake_call_tool},
+            )
+
+    result = asyncio.run(scenario())
+    assert result == {"ok": True}
+    assert observed["tool_name"] is None

--- a/tests/metering/test_compat_guard.py
+++ b/tests/metering/test_compat_guard.py
@@ -1,0 +1,44 @@
+"""Unit tests for the <3.12 compatibility guard (Task 22 ruling #2).
+
+Unlike the rest of ``tests/metering/``, this module runs on EVERY supported
+Python version, including the repo's 3.10 floor -- it is the test that
+proves the guard behaves correctly on both sides of the 3.12 boundary. All
+other ``tests/metering/*`` modules are ``skipif`` guarded (they exercise
+the real ``mcp_outbound_metering`` package, which is only installed on
+3.12); this one exercises the guard itself and must run everywhere.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from amazon_ads_mcp.metering import compat
+
+
+def test_compat_module_always_importable() -> None:
+    """Importing amazon_ads_mcp.metering.compat must never raise, on any
+    supported Python version -- that is the entire point of the guard."""
+    assert hasattr(compat, "METERING_AVAILABLE")
+
+
+def test_availability_matches_python_version_floor() -> None:
+    if sys.version_info < compat.METERING_MIN_PYTHON:
+        assert compat.METERING_AVAILABLE is False
+        assert compat.MeteringRuntime is None
+        assert compat.MeteringConfigError is None
+        assert compat.MeteringError is None
+    else:
+        assert compat.METERING_AVAILABLE is True
+        assert compat.MeteringRuntime is not None
+        assert compat.MeteringConfigError is not None
+        assert compat.MeteringError is not None
+
+
+def test_warn_unsupported_logs_a_loud_warning(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="amazon_ads_mcp.metering.compat"):
+        compat.warn_unsupported()
+    assert any(
+        "Python>=3.12" in record.message and record.levelno == logging.WARNING
+        for record in caplog.records
+    )

--- a/tests/metering/test_compat_guard.py
+++ b/tests/metering/test_compat_guard.py
@@ -42,3 +42,14 @@ def test_warn_unsupported_logs_a_loud_warning(caplog) -> None:
         "Python>=3.12" in record.message and record.levelno == logging.WARNING
         for record in caplog.records
     )
+
+
+def test_warn_unsupported_names_the_install_extra(caplog) -> None:
+    """Fix round 2, deployment gap #2: mcp-outbound-metering moved to the
+    optional "metering" extra -- the operator-facing message must name
+    the exact install command, not just say "not installed"."""
+    with caplog.at_level(logging.WARNING, logger="amazon_ads_mcp.metering.compat"):
+        compat.warn_unsupported()
+    assert any(
+        "amazon-ads-mcp[metering]" in record.message for record in caplog.records
+    )

--- a/tests/metering/test_conformance.py
+++ b/tests/metering/test_conformance.py
@@ -1,0 +1,33 @@
+"""§8.3 "Conformance + verify": `create_conformance_harness` builds the
+REAL `AuthenticatedClient` stack over the harness's mock upstream, and
+`ProducerConformanceSuite` (the shared 11-scenario contract suite, design
+§3.5.5) passes 11/11 through it -- zero overrides, per the documented
+subclass pattern (see `mcp_outbound_metering.conformance.suite`'s module
+docstring and `examples/httpx/test_conformance.py` in the billing repo).
+
+`test_cli_verify_subprocess.py` covers the second half of this §8.3
+bullet (`mcp-metering verify` exits 0) as a separate subprocess test.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from mcp_outbound_metering.conformance import ProducerConformanceSuite
+
+    from amazon_ads_mcp.metering.conformance import create_conformance_harness
+
+
+if sys.version_info >= (3, 12):
+
+    class TestAmazonAdsMcpMeteringConformance(ProducerConformanceSuite):
+        @pytest.fixture
+        def harness_factory(self):
+            return create_conformance_harness

--- a/tests/metering/test_construction_order_independence.py
+++ b/tests/metering/test_construction_order_independence.py
@@ -1,0 +1,225 @@
+"""Fix round 1, CRITICAL: the metering wrap must be TIMING-INDEPENDENT.
+
+Empirically reproduced by review: `create_amazon_ads_server()` builds the
+shared `AuthenticatedClient` via `ServerBuilder.build()` BEFORE
+`mcp.run()` ever triggers `server_lifespan()`, where `start_metering()`
+actually runs. The original `install_metered_transport()` made a
+ONE-SHOT decision at `__init__` time (`if get_metering_runtime() is None:
+return inner unchanged`) -- for the shared client, that decision was made
+while no runtime existed yet, and captured `runtime=None` PERMANENTLY:
+the shared client (used for every OpenAPI-mounted tool call) would never
+be metered in the real running server, no matter how long the server ran
+afterward.
+
+Fix: `LazyMeteredTransport` (`metering/adapter.py`) is now installed
+UNCONDITIONALLY at `__init__` time, and defers the actual metering
+decision to REQUEST time via `get_metering_runtime()` -- removing all
+construction-order sensitivity. This module proves that directly, plus
+drives the REAL boot order end-to-end (`ServerBuilder.build()` then
+`server_lifespan()`, exactly as `create_amazon_ads_server()` +
+`mcp.run()` would) as the most faithful reproduction of the reviewer's
+finding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import (
+        LazyMeteredTransport,
+        get_metering_runtime,
+        set_metering_runtime,
+    )
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_metering_runtime():
+    assert get_metering_runtime() is None
+    yield
+    set_metering_runtime(None)
+
+
+# -- (a) construct BEFORE start_metering, activate, THEN send -------------
+
+
+def test_client_constructed_before_activation_still_gets_metered(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+
+        # Construct the client while NO runtime is active -- mirrors the
+        # real boot order (ServerBuilder.build() runs before
+        # server_lifespan()).
+        assert get_metering_runtime() is None
+        upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+        client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+        assert isinstance(client._transport, LazyMeteredTransport)
+
+        # A request made before activation must succeed, unmetered.
+        response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+        assert response.status_code == 200
+        await asyncio.sleep(0.05)
+        assert ingest.events() == []
+
+        # NOW metering activates (mirrors server_lifespan's
+        # start_metering(), which runs after the client already exists).
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            response = await client.get(f"https://{ALLOWED_HOST}/v2/campaigns")
+            assert response.status_code == 200
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
+            assert events[0]["data"]["url.path"] == "/v2/campaigns"
+        finally:
+            await client.aclose()
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+# -- (b) deactivate -> subsequent sends unmetered, no errors --------------
+
+
+def test_deactivation_makes_subsequent_sends_unmetered_without_errors(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+
+        upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+        client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+        try:
+            response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+            assert response.status_code == 200
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
+
+            # Deactivate (mirrors server_lifespan's stop_metering()).
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+            # Subsequent sends on the SAME client object must succeed,
+            # unmetered -- no errors, no new events.
+            response = await client.get(f"https://{ALLOWED_HOST}/v2/campaigns")
+            assert response.status_code == 200
+            await asyncio.sleep(0.05)
+            assert len(ingest.events()) == 1  # unchanged -- no new event
+        finally:
+            await client.aclose()
+
+    asyncio.run(scenario())
+
+
+# -- (c) existing activate-first behavior is unaffected --------------------
+
+
+def test_activate_first_still_works(tmp_path) -> None:
+    """Sanity: the ordinary (already-covered-elsewhere) activate-then-
+    construct-then-send path still works under the new lazy design."""
+
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+            client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+            try:
+                response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+                assert response.status_code == 200
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+# -- the reviewer's literal reproduction: real ServerBuilder + lifespan ---
+
+
+def test_real_boot_order_shared_client_becomes_metered_once_lifespan_starts(
+    tmp_path, monkeypatch
+) -> None:
+    """Drives the REAL boot order: ServerBuilder.build() constructs the
+    shared client (the exact call create_amazon_ads_server() makes)
+    BEFORE server_lifespan() (the exact function passed to FastMCP's
+    lifespan=) ever runs. Only the shared client's innermost transport is
+    swapped for a MockTransport post-construction (avoiding a real
+    network call) -- everything else is the real construction path.
+    """
+    from amazon_ads_mcp.server import mcp_server
+    from amazon_ads_mcp.server.mcp_server import server_lifespan
+    from amazon_ads_mcp.server.server_builder import ServerBuilder
+
+    from ._support import CONFIG_PATH, base_env
+
+    monkeypatch.setattr(mcp_server, "_cleanup_done", False)
+
+    env = base_env(tmp_path)
+    env["METERING_CONFIG"] = str(CONFIG_PATH)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    async def scenario():
+        # Step 1: build the server -- this is exactly what
+        # create_amazon_ads_server() does, and it runs BEFORE lifespan.
+        builder = ServerBuilder(lifespan=server_lifespan)
+        await builder.build()
+        shared_client = builder.client
+        assert isinstance(shared_client, AuthenticatedClient)
+        assert isinstance(shared_client._transport, LazyMeteredTransport)
+        assert get_metering_runtime() is None  # lifespan hasn't run yet
+
+        # Swap the shared client's innermost transport for a mock so the
+        # test never touches the real network -- white-box on our OWN
+        # LazyMeteredTransport, not on httpx internals.
+        recorded = {"calls": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded["calls"] += 1
+            return httpx.Response(200)
+
+        shared_client._transport._inner = httpx.MockTransport(handler)
+        shared_client.auth_manager = FakeAuthManager()
+
+        # Step 2: NOW the lifespan runs (mirrors mcp.run() triggering it
+        # after build() already returned) -- this is where
+        # start_metering() actually activates a runtime.
+        async with server_lifespan(SimpleNamespace()):
+            assert get_metering_runtime() is not None
+
+            response = await shared_client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+            assert response.status_code == 200
+            assert recorded["calls"] == 1
+
+            runtime = get_metering_runtime()
+            # health().transports aggregates stats from every transport
+            # this runtime has wrapped -- a nonzero attempt_count here
+            # proves the SHARED (pre-lifespan-built) client's request was
+            # genuinely metered, not merely unbroken.
+            health = runtime.health()
+            assert health["transports"]["attempt_count"] >= 1
+
+        assert get_metering_runtime() is None
+        await shared_client.aclose()
+
+    asyncio.run(scenario())

--- a/tests/metering/test_context.py
+++ b/tests/metering/test_context.py
@@ -1,0 +1,77 @@
+"""Unit tests for usage_context()/tenant_key() (Task 22 ruling #4).
+
+Not skipif-guarded: ``amazon_ads_mcp.metering.context`` has no dependency
+on ``mcp_outbound_metering`` -- only on this repo's own auth/session-state
+modules -- so it is tested on every supported Python version, same
+rationale as ``test_compat_guard.py``/``test_normalizer.py``/
+``test_attribution.py``. Relies on ``tests/conftest.py``'s autouse
+``mock_env_vars`` (AUTH_METHOD=direct with test credentials) and
+``_reset_session_state`` fixtures for isolation between tests.
+"""
+
+from __future__ import annotations
+
+from amazon_ads_mcp.auth.manager import get_auth_manager
+from amazon_ads_mcp.auth.session_state import set_active_identity
+from amazon_ads_mcp.metering.attribution import tool_name_scope
+from amazon_ads_mcp.metering.context import tenant_key, usage_context
+from amazon_ads_mcp.models import Identity
+
+
+def test_usage_context_allowlist_keys_only() -> None:
+    dims = usage_context()
+    assert set(dims) == {"identity_id", "profile_id", "region", "auth_method", "tool_name"}
+
+
+def test_usage_context_with_no_active_identity_is_all_none_but_present() -> None:
+    dims = usage_context()
+    assert dims["identity_id"] is None
+    assert dims["tool_name"] is None
+    # auth_method comes from the configured provider even with no active
+    # identity -- mock_env_vars configures AUTH_METHOD=direct.
+    assert dims["auth_method"] == "direct"
+
+
+def test_usage_context_reflects_active_identity() -> None:
+    identity = Identity(id="identity-123", attributes={"region": "eu"})
+    set_active_identity(identity)
+    dims = usage_context()
+    assert dims["identity_id"] == "identity-123"
+
+
+def test_tenant_key_matches_identity_id_dimension() -> None:
+    identity = Identity(id="identity-456", attributes={})
+    set_active_identity(identity)
+    assert tenant_key() == "identity-456"
+    assert tenant_key() == usage_context()["identity_id"]
+
+
+def test_tenant_key_none_without_active_identity() -> None:
+    assert tenant_key() is None
+
+
+def test_usage_context_reflects_active_profile_id() -> None:
+    identity = Identity(id="identity-789", attributes={})
+    set_active_identity(identity)
+    get_auth_manager().set_active_profile_id("profile-abc")
+    dims = usage_context()
+    assert dims["profile_id"] == "profile-abc"
+
+
+def test_usage_context_reflects_tool_name_scope() -> None:
+    assert usage_context()["tool_name"] is None
+    with tool_name_scope("search_profiles"):
+        assert usage_context()["tool_name"] == "search_profiles"
+    assert usage_context()["tool_name"] is None
+
+
+def test_usage_context_auth_method_reflects_provider_type() -> None:
+    assert usage_context()["auth_method"] == get_auth_manager().provider.provider_type
+
+
+def test_usage_context_region_defaults_to_none_without_routing_state() -> None:
+    # _ROUTING_STATE_VAR defaults to {} (utils/http_client.py) until a real
+    # request runs `_inject_headers`'s region-routing block; before that,
+    # region is None -- not a KeyError, not an empty-dict dimension value.
+    dims = usage_context()
+    assert dims["region"] is None

--- a/tests/metering/test_lifespan.py
+++ b/tests/metering/test_lifespan.py
@@ -1,0 +1,123 @@
+"""Unit tests for metering/lifespan.py (Task 22 ruling #8): the
+gate/strict-failure logic behind `server_lifespan()`'s metering
+start/stop, tested without spinning up a full FastMCP server.
+
+Billing-critical rule under test: METERING_ENABLED=true (strictly) that
+fails to start metering must FAIL server startup, never silently continue
+without metering. A looser "truthy" value (attempted but not exactly
+"true") degrades non-fatally on failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering import lifespan as metering_lifespan
+    from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime
+
+    from ._support import CONFIG_PATH, base_env
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime():
+    assert get_metering_runtime() is None
+    yield
+    set_metering_runtime(None)
+
+
+def test_unset_metering_enabled_is_a_silent_no_op() -> None:
+    async def scenario():
+        return await metering_lifespan.start_metering(env={})
+
+    result = asyncio.run(scenario())
+    assert result is None
+    assert get_metering_runtime() is None
+
+
+def test_false_metering_enabled_is_a_silent_no_op() -> None:
+    async def scenario():
+        return await metering_lifespan.start_metering(env={"METERING_ENABLED": "false"})
+
+    result = asyncio.run(scenario())
+    assert result is None
+    assert get_metering_runtime() is None
+
+
+def test_strictly_true_and_available_starts_and_installs_runtime(tmp_path) -> None:
+    env = base_env(tmp_path)
+    env["METERING_CONFIG"] = str(CONFIG_PATH)
+
+    async def scenario():
+        runtime = await metering_lifespan.start_metering(env=env)
+        assert runtime is get_metering_runtime()
+        await metering_lifespan.stop_metering()
+        return runtime
+
+    runtime = asyncio.run(scenario())
+    assert runtime is not None
+    assert get_metering_runtime() is None  # cleared by stop_metering
+
+
+def test_strictly_true_with_malformed_config_fails_startup(tmp_path) -> None:
+    """Billing-critical: METERING_ENABLED=true (strict) + a startup
+    failure (here: a missing/invalid config file) must RAISE, not
+    silently continue without metering."""
+    env = {"METERING_ENABLED": "true", "METERING_CONFIG": str(tmp_path / "does-not-exist.yaml")}
+
+    async def scenario():
+        await metering_lifespan.start_metering(env=env)
+
+    with pytest.raises(Exception):
+        asyncio.run(scenario())
+    assert get_metering_runtime() is None
+
+
+def test_loosely_truthy_but_not_strict_degrades_non_fatally_on_failure(tmp_path) -> None:
+    """METERING_ENABLED=1 is truthy enough to ATTEMPT startup (so a
+    genuine misconfiguration gets logged, not silently ignored) but is
+    not the strict "true" the billing-critical rule requires -- a
+    failure here must NOT raise."""
+    env = {"METERING_ENABLED": "1", "METERING_CONFIG": str(tmp_path / "does-not-exist.yaml")}
+
+    async def scenario():
+        return await metering_lifespan.start_metering(env=env)
+
+    result = asyncio.run(scenario())
+    assert result is None
+    assert get_metering_runtime() is None
+
+
+def test_stop_metering_is_idempotent_and_safe_when_never_started() -> None:
+    async def scenario():
+        await metering_lifespan.stop_metering()
+        await metering_lifespan.stop_metering()
+
+    asyncio.run(scenario())  # must not raise
+    assert get_metering_runtime() is None
+
+
+def test_health_payload_none_when_no_active_runtime() -> None:
+    assert metering_lifespan.metering_health_payload() is None
+
+
+def test_health_payload_reflects_active_runtime(tmp_path) -> None:
+    env = base_env(tmp_path)
+    env["METERING_CONFIG"] = str(CONFIG_PATH)
+
+    async def scenario():
+        await metering_lifespan.start_metering(env=env)
+        payload = metering_lifespan.metering_health_payload()
+        await metering_lifespan.stop_metering()
+        return payload
+
+    payload = asyncio.run(scenario())
+    assert payload is not None
+    assert payload["status"] in ("healthy", "degraded", "unhealthy")

--- a/tests/metering/test_lifespan_guard.py
+++ b/tests/metering/test_lifespan_guard.py
@@ -39,8 +39,12 @@ def test_strict_enabled_raises_when_metering_unavailable(monkeypatch) -> None:
     async def scenario():
         await lifespan.start_metering(env={"METERING_ENABLED": "true"})
 
-    with pytest.raises(RuntimeError, match="METERING_ENABLED=true"):
+    with pytest.raises(RuntimeError, match="METERING_ENABLED=true") as excinfo:
         asyncio.run(scenario())
+    # Fix round 2, deployment gap #2: mcp-outbound-metering moved behind
+    # the optional "metering" extra -- the exception operators actually
+    # see must name the exact install command, not just say it's missing.
+    assert "amazon-ads-mcp[metering]" in str(excinfo.value)
     assert get_metering_runtime() is None
 
 

--- a/tests/metering/test_lifespan_guard.py
+++ b/tests/metering/test_lifespan_guard.py
@@ -1,0 +1,73 @@
+"""Billing-critical guard test (Task 22 ruling #2 + #8): strict
+METERING_ENABLED=true FAILS server startup on an interpreter where
+metering is unavailable (<3.12, or a failed import) -- it must never
+silently continue without metering.
+
+Not skipif-guarded, same rationale as `test_compat_guard.py`:
+`amazon_ads_mcp.metering.lifespan` has no module-level dependency on
+`mcp_outbound_metering` (only on `compat`, which is always importable),
+so this is the one test file that specifically proves the STRICT-failure
+behavior on the repo's 3.10 floor, where `compat.METERING_AVAILABLE` is
+naturally `False` -- exactly the scenario the billing-critical rule
+exists for. On 3.12 with the package installed, this same assertion is
+covered indirectly by `test_lifespan.py`'s malformed-config strict-failure
+test (metering IS available there, so unavailability can't be exercised;
+this file's `test_strict_enabled_raises_when_metering_unavailable` fills
+that gap by simulating unavailability directly).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from amazon_ads_mcp.metering import compat, lifespan
+from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime():
+    assert get_metering_runtime() is None
+    yield
+    set_metering_runtime(None)
+
+
+def test_strict_enabled_raises_when_metering_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(compat, "METERING_AVAILABLE", False)
+
+    async def scenario():
+        await lifespan.start_metering(env={"METERING_ENABLED": "true"})
+
+    with pytest.raises(RuntimeError, match="METERING_ENABLED=true"):
+        asyncio.run(scenario())
+    assert get_metering_runtime() is None
+
+
+def test_loosely_enabled_does_not_raise_when_metering_unavailable(monkeypatch, caplog) -> None:
+    import logging
+
+    monkeypatch.setattr(compat, "METERING_AVAILABLE", False)
+
+    async def scenario():
+        return await lifespan.start_metering(env={"METERING_ENABLED": "1"})
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(scenario())
+    assert result is None
+    assert get_metering_runtime() is None
+    assert any("Python>=3.12" in r.message for r in caplog.records)
+
+
+def test_unset_never_warns_even_when_metering_unavailable(monkeypatch, caplog) -> None:
+    import logging
+
+    monkeypatch.setattr(compat, "METERING_AVAILABLE", False)
+
+    async def scenario():
+        return await lifespan.start_metering(env={})
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(scenario())
+    assert result is None
+    assert not any("Python>=3.12" in r.message for r in caplog.records)

--- a/tests/metering/test_normalizer.py
+++ b/tests/metering/test_normalizer.py
@@ -1,0 +1,55 @@
+"""Unit tests for the path normalizer (Task 22 ruling #7).
+
+Not skipif-guarded: ``amazon_ads_mcp.metering.normalizer`` has no
+dependency on ``mcp_outbound_metering`` (only ``httpx``, already a core
+dependency), so it is safe -- and useful -- to test on every supported
+Python version, same rationale as ``test_compat_guard.py``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from amazon_ads_mcp.metering.normalizer import normalize_path
+
+
+def _req(path: str) -> httpx.Request:
+    return httpx.Request("GET", f"https://advertising-api.amazon.com{path}")
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/v2/profiles", "/v2/profiles"),
+        ("/v2/campaigns/42", "/v2/campaigns/{id}"),
+        ("/v2/campaigns/42/adGroups/7", "/v2/campaigns/{id}/adGroups/{id}"),
+        ("/v2/profiles/A1B2C3D4E5F6", "/v2/profiles/{id}"),
+        (
+            "/reporting/reports/550e8400-e29b-41d4-a716-446655440000",
+            "/reporting/reports/{id}",
+        ),
+        ("/v2/campaigns", "/v2/campaigns"),
+    ],
+)
+def test_normalize_path_collapses_high_cardinality_segments(path: str, expected: str) -> None:
+    assert normalize_path(_req(path)) == expected
+
+
+def test_normalize_path_never_includes_query_string() -> None:
+    request = httpx.Request(
+        "GET",
+        "https://advertising-api.amazon.com/v2/campaigns/42",
+        params={"token": "s3cret"},
+    )
+    result = normalize_path(request)
+    assert "?" not in result
+    assert "token" not in result
+    assert "s3cret" not in result
+    assert result == "/v2/campaigns/{id}"
+
+
+def test_normalize_path_short_alpha_segment_is_stable() -> None:
+    # A short alpha-only segment (not a pure-digit, not an Amazon entity-id
+    # shape, not a UUID) must never be collapsed.
+    assert normalize_path(_req("/v2/profiles/summary")) == "/v2/profiles/summary"

--- a/tests/metering/test_oauth_exclusion.py
+++ b/tests/metering/test_oauth_exclusion.py
@@ -1,0 +1,109 @@
+"""§8.3 "OAuth exclusion": each provider's `_get_client()` yields an
+unwrapped plain client even with an active metering runtime (Task 22
+boundary requirement -- OAuth/OpenBridge/Kuudo provider clients are
+structurally unmetered and must never be touched).
+
+Verified repo facts: `DirectAmazonAdsProvider._get_client()` and
+`OpenBridgeAuthProvider._get_client()` both return
+`utils.http.get_http_client()` with `authenticated` defaulting to
+`False`, which routes to `HTTPClientManager.get_client()` with NO
+`client_class` -- i.e. a plain `httpx.AsyncClient`, never
+`AuthenticatedClient`. `KuudoAuthProvider._get_client()` constructs a
+plain `httpx.AsyncClient(...)` directly. None of the three ever passes
+through `AuthenticatedClient.__init__` (the ONE seam that calls
+`install_metered_transport`), so an active runtime can structurally never
+reach them -- this test proves that boundary holds for all three.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from mcp_outbound_metering.transport import MeteredAsyncTransport
+
+    from amazon_ads_mcp.metering.adapter import set_metering_runtime
+
+    from ._support import build_runtime
+
+
+@pytest.fixture
+def _active_runtime(tmp_path):
+    async def _build():
+        return await build_runtime(tmp_path)
+
+    runtime = asyncio.run(_build())
+    set_metering_runtime(runtime)
+    try:
+        yield runtime
+    finally:
+        set_metering_runtime(None)
+        asyncio.run(runtime.aclose())
+
+
+def _assert_unwrapped(client: httpx.AsyncClient) -> None:
+    assert type(client) is httpx.AsyncClient
+    assert not isinstance(client._transport, MeteredAsyncTransport)
+
+
+def test_direct_provider_get_client_is_unwrapped(_active_runtime) -> None:
+    from amazon_ads_mcp.auth.base import ProviderConfig
+    from amazon_ads_mcp.auth.providers.direct import DirectAmazonAdsProvider
+
+    provider = DirectAmazonAdsProvider(
+        ProviderConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            refresh_token="test-refresh-token",
+        )
+    )
+
+    async def scenario():
+        client = await provider._get_client()
+        _assert_unwrapped(client)
+
+    asyncio.run(scenario())
+
+
+def test_openbridge_provider_get_client_is_unwrapped(_active_runtime) -> None:
+    from amazon_ads_mcp.auth.base import ProviderConfig
+    from amazon_ads_mcp.auth.providers.openbridge import OpenBridgeProvider
+
+    provider = OpenBridgeProvider(ProviderConfig(refresh_token="test-openbridge-token"))
+
+    async def scenario():
+        client = await provider._get_client()
+        _assert_unwrapped(client)
+
+    asyncio.run(scenario())
+
+
+def test_kuudo_provider_get_client_is_unwrapped(_active_runtime) -> None:
+    from amazon_ads_mcp.auth.base import ProviderConfig
+    from amazon_ads_mcp.auth.providers.kuudo import KuudoAmazonAdsProvider
+
+    provider = KuudoAmazonAdsProvider(
+        ProviderConfig(
+            base_url="https://app.kuudo.test",
+            api_key="sk_test",
+            provider="amazon_ads",
+        )
+    )
+
+    async def scenario():
+        client = await provider._get_client()
+        # Kuudo builds a raw httpx.AsyncClient directly (no
+        # get_http_client() indirection) -- same assertion, different
+        # construction path.
+        _assert_unwrapped(client)
+        await client.aclose()
+
+    asyncio.run(scenario())

--- a/tests/metering/test_packaged_config.py
+++ b/tests/metering/test_packaged_config.py
@@ -1,0 +1,163 @@
+"""Fix round 2, deployment gap #1: metering.yaml must resolve correctly
+in packaged/Docker deployments, not just a repo checkout.
+
+Docker's runtime image copies the venv + dist/openapi + entrypoint into
+/app but NOT the repo-root metering.yaml, and a wheel install only ships
+package resources -- METERING_ENABLED=true without METERING_CONFIG would
+otherwise resolve "metering.yaml" relative to CWD and fail to find it,
+either failing strict startup or silently disabling metering. Fix:
+metering.yaml is now ALSO packaged at
+src/amazon_ads_mcp/metering/metering.yaml, and
+amazon_ads_mcp.metering.config.resolve_config_path() falls back to it via
+importlib.resources when no METERING_CONFIG is set and no ./metering.yaml
+exists in CWD.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT_CONFIG = REPO_ROOT / "metering.yaml"
+PACKAGED_CONFIG = REPO_ROOT / "src" / "amazon_ads_mcp" / "metering" / "metering.yaml"
+
+
+# -- drift guard: not skipif-guarded -- these are plain files, no --------
+# -- mcp_outbound_metering dependency, so this runs on every Python ------
+# -- version, same rationale as test_normalizer.py etc. -------------------
+
+
+def test_packaged_config_matches_repo_root_byte_identical() -> None:
+    """Drift guard: the packaged copy must be byte-identical to the
+    tracked repo-root metering.yaml. If you edit one, edit both (or copy
+    one over the other) -- this test exists specifically to catch the
+    two silently diverging over time."""
+    assert REPO_ROOT_CONFIG.is_file()
+    assert PACKAGED_CONFIG.is_file()
+    assert REPO_ROOT_CONFIG.read_bytes() == PACKAGED_CONFIG.read_bytes()
+
+
+def test_packaged_config_is_schema_valid() -> None:
+    import yaml
+    from jsonschema import Draft202012Validator
+
+    # Import lazily: catalog.schema_for lives in mcp_outbound_metering,
+    # only available on 3.12 -- skip cleanly on <3.12 rather than failing
+    # collection (this one check genuinely needs the producer package;
+    # the byte-identity check above does not).
+    pytest.importorskip("mcp_outbound_metering")
+    from mcp_outbound_metering import catalog
+
+    config = yaml.safe_load(PACKAGED_CONFIG.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(catalog.schema_for(catalog.METERING_CONFIG_V1))
+    errors = list(validator.iter_errors(config))
+    assert not errors, [e.message for e in errors]
+
+
+# -- resolve_config_path() unit tests (no mcp_outbound_metering needed) --
+
+
+def test_resolve_config_path_prefers_explicit_env(tmp_path, monkeypatch) -> None:
+    from amazon_ads_mcp.metering.config import resolve_config_path
+
+    explicit = tmp_path / "custom-metering.yaml"
+    explicit.write_text("schema_version: 1\n")
+    monkeypatch.chdir(tmp_path)
+
+    resolved = resolve_config_path({"METERING_CONFIG": str(explicit)})
+    assert resolved == explicit
+
+
+def test_resolve_config_path_prefers_cwd_relative_over_packaged(tmp_path, monkeypatch) -> None:
+    from amazon_ads_mcp.metering.config import resolve_config_path
+
+    cwd_config = tmp_path / "metering.yaml"
+    cwd_config.write_text("schema_version: 1\n")
+    monkeypatch.chdir(tmp_path)
+
+    resolved = resolve_config_path({})
+    assert resolved.resolve() == cwd_config.resolve()
+
+
+def test_resolve_config_path_falls_back_to_packaged_resource(tmp_path, monkeypatch) -> None:
+    """The reviewer's exact packaged-deployment reproduction: chdir to an
+    EMPTY tmp dir (no ./metering.yaml, mirroring /app in the Docker
+    runtime image), no METERING_CONFIG -> resolves the packaged
+    resource, and its content matches the repo-root file."""
+    from amazon_ads_mcp.metering.config import resolve_config_path
+
+    monkeypatch.chdir(tmp_path)
+    assert not (tmp_path / "metering.yaml").exists()
+
+    resolved = resolve_config_path({})
+    assert resolved.is_file()
+    assert resolved.read_bytes() == REPO_ROOT_CONFIG.read_bytes()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="metering requires Python>=3.12")
+def test_strict_startup_succeeds_from_packaged_config_in_empty_cwd(tmp_path, monkeypatch) -> None:
+    """The reviewer's exact reproduction, end to end: strict
+    METERING_ENABLED=true, an empty CWD (no ./metering.yaml), no
+    METERING_CONFIG -> start_metering() succeeds by resolving the
+    packaged resource, not by raising."""
+    import asyncio
+
+    from amazon_ads_mcp.metering import lifespan as metering_lifespan
+    from amazon_ads_mcp.metering.adapter import get_metering_runtime, set_metering_runtime
+
+    from ._support import base_env
+
+    monkeypatch.chdir(tmp_path)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    assert not (tmp_path / "metering.yaml").exists()
+
+    env = base_env(workdir)
+    # No METERING_CONFIG -- must fall through to the packaged resource.
+    env.pop("METERING_CONFIG", None)
+
+    async def scenario():
+        runtime = await metering_lifespan.start_metering(env=env)
+        assert runtime is not None
+        assert get_metering_runtime() is runtime
+        await metering_lifespan.stop_metering()
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        set_metering_runtime(None)
+
+
+@pytest.mark.slow
+def test_wheel_contains_the_packaged_metering_config(tmp_path) -> None:
+    """Build a REAL wheel and inspect its contents directly, rather than
+    trusting the pyproject.toml [[tool.poetry.include]] config in the
+    abstract -- mirrors mcp_outbound_metering's own
+    test_wheel_contains_the_install_templates (billing repo,
+    packages/python/mcp_outbound_metering/tests/test_package.py)."""
+    env = dict(os.environ)
+    result = subprocess.run(
+        ["uv", "build", "--wheel", "-o", str(tmp_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    wheels = list(tmp_path.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+
+    with zipfile.ZipFile(wheels[0]) as archive:
+        names = set(archive.namelist())
+        assert "amazon_ads_mcp/metering/metering.yaml" in names
+        packaged_bytes = archive.read("amazon_ads_mcp/metering/metering.yaml")
+
+    assert packaged_bytes == REPO_ROOT_CONFIG.read_bytes()

--- a/tests/metering/test_profile_flow.py
+++ b/tests/metering/test_profile_flow.py
@@ -1,0 +1,133 @@
+"""§8.3 "Profile flow": `tools/profile_listing._fetch_profiles` produces
+exactly one `/v2/profiles` usage event per real upstream call, and a
+repeat call served from `ProfileCache` (this repo DOES have a cache layer
+-- `tools/profile_listing.ProfileCache`, keyed by (identity, region) --
+so the §8.3 cache-hit bullet is exercised directly here, not documented
+N/A) produces no second event.
+
+Drives `_fetch_profiles` for real (the second construction path:
+`get_http_client(authenticated=True, ...)` ->
+`HTTPClientManager.get_client(client_class=AuthenticatedClient)`), with
+only the ONE network-touching seam (`profile_listing.get_http_client`)
+replaced by an equivalent that still constructs a REAL
+`AuthenticatedClient` (so the real transport-wrap runs) over a
+MockTransport standing in for the real Amazon Ads API -- "smallest
+driveable wrapper" per the brief, since `_fetch_profiles` itself exposes
+no transport-injection seam and this task must not modify its production
+code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import set_metering_runtime
+    from amazon_ads_mcp.tools import profile_listing
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+    from ._support import ALLOWED_HOST, RecordingIngestTransport, build_runtime
+
+
+class _FakeProfileAuthManager:
+    """Enough of the `AuthManager` surface for `_fetch_profiles` and
+    `_get_cache_key` -- no real provider, no real network."""
+
+    provider = None
+
+    def __init__(self, identity_id: str = "identity-profiles-1", region: str = "na") -> None:
+        self._identity_id = identity_id
+        self._region = region
+
+    async def get_active_credentials(self) -> SimpleNamespace:
+        return SimpleNamespace(base_url=f"https://{ALLOWED_HOST}")
+
+    async def get_headers(self) -> dict:
+        return {
+            "Authorization": "Bearer conformance-test-token",
+            "Amazon-Advertising-API-ClientId": "conformance-test-client-id",
+        }
+
+    def get_active_identity_id(self):
+        return self._identity_id
+
+    def get_active_region(self):
+        return self._region
+
+
+def _profiles_payload() -> list:
+    return [
+        {
+            "profileId": 1,
+            "countryCode": "US",
+            "accountInfo": {"name": "Acme Ads", "type": "seller"},
+        }
+    ]
+
+
+def test_fetch_profiles_emits_one_event_then_cache_hit_emits_none(tmp_path, monkeypatch) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+
+        upstream_calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            upstream_calls["n"] += 1
+            assert request.url.path == "/v2/profiles"
+            return httpx.Response(200, json=_profiles_payload())
+
+        upstream = httpx.MockTransport(handler)
+
+        async def fake_get_http_client(*, authenticated, auth_manager, base_url, **_ignored):
+            # Same real construction path (AuthenticatedClient.__init__,
+            # which installs the metered transport) -- only the network
+            # socket is replaced.
+            return AuthenticatedClient(transport=upstream, auth_manager=auth_manager, base_url=base_url)
+
+        fake_auth_manager = _FakeProfileAuthManager()
+        monkeypatch.setattr(profile_listing, "get_http_client", fake_get_http_client)
+        monkeypatch.setattr(profile_listing, "get_auth_manager", lambda: fake_auth_manager)
+        profile_listing._profile_cache.clear(profile_listing._get_cache_key())
+
+        try:
+            # First call (via the cached wrapper -- the real call shape
+            # every tool uses; an empty cache means it drives
+            # `_fetch_profiles` as its fetcher): a real upstream hit, one
+            # usage event.
+            profiles, stale = await profile_listing._get_profiles_cached()
+            assert profiles == _profiles_payload()
+            assert stale is False
+            assert upstream_calls["n"] == 1
+
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
+            assert events[0]["data"]["url.path"] == "/v2/profiles"
+
+            # Second call through the cached wrapper, same identity/region
+            # key, within TTL: served from ProfileCache -- no second
+            # upstream call, no second event.
+            cached_profiles, stale = await profile_listing._get_profiles_cached()
+            assert cached_profiles == _profiles_payload()
+            assert stale is False
+            assert upstream_calls["n"] == 1  # still just the one real call
+
+            # Give the (idle) flusher a beat -- there is nothing new to
+            # flush, so the event count must stay at 1.
+            await asyncio.sleep(0.05)
+            assert len(ingest.events()) == 1
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())

--- a/tests/metering/test_proxy_mounts.py
+++ b/tests/metering/test_proxy_mounts.py
@@ -1,0 +1,112 @@
+"""Fix round 1, IMPORTANT: proxy mounts must not bypass the metering seam.
+
+httpx auto-populates `AsyncClient._mounts` from `HTTP_PROXY`/`HTTPS_PROXY`/
+`ALL_PROXY` env vars when `trust_env=True` (httpx's default, and nothing
+in this repo overrides it -- verified: no construction path anywhere
+passes `trust_env=False`). `Client._transport_for_url` checks `_mounts`
+BEFORE falling back to `self._transport`, so a populated mount transport
+completely bypasses whatever wraps `self._transport` alone. Fix:
+`AuthenticatedClient.__init__` also wraps every populated `_mounts` value
+with its own `LazyMeteredTransport`. `trust_env` itself is left
+UNCHANGED (product behavior, not this task's to alter) -- proxied Amazon
+Ads traffic gets metered (subject to the same host allowlist), other
+proxied traffic passes through unmetered by policy, same as always.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import (
+        LazyMeteredTransport,
+        get_metering_runtime,
+        set_metering_runtime,
+    )
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_metering_runtime():
+    assert get_metering_runtime() is None
+    yield
+    set_metering_runtime(None)
+
+
+def test_proxy_env_populates_mounts_wrapped_in_lazy_metered_transport(monkeypatch) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.test:8080")
+
+    client = AuthenticatedClient(auth_manager=FakeAuthManager())
+    try:
+        assert client._mounts, "expected HTTPS_PROXY to populate _mounts"
+        for pattern, mount in client._mounts.items():
+            assert mount is not None
+            assert isinstance(mount, LazyMeteredTransport)
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_amazon_host_request_via_proxy_mount_is_metered_when_active(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.test:8080")
+
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            client = AuthenticatedClient(auth_manager=FakeAuthManager())
+            assert client._mounts, "expected HTTPS_PROXY to populate _mounts"
+
+            # Replace the proxy mount's inner transport with a mock so
+            # the request never touches a real proxy/network -- white-box
+            # on our own LazyMeteredTransport wrapping it.
+            for pattern, mount in client._mounts.items():
+                assert isinstance(mount, LazyMeteredTransport)
+                mount._inner = httpx.MockTransport(lambda request: httpx.Response(200))
+
+            try:
+                response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+                assert response.status_code == 200
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
+            assert events[0]["data"]["server.address"] == ALLOWED_HOST
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_no_proxy_env_leaves_mounts_empty(monkeypatch) -> None:
+    """Negative control: the ordinary case (no proxy env vars) still
+    leaves `_mounts` empty, exactly as before this fix. Explicitly
+    unsets every proxy var httpx's trust_env consults, rather than
+    relying on the ambient shell happening not to have one set."""
+    for var in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    client = AuthenticatedClient(auth_manager=FakeAuthManager())
+    try:
+        assert client._mounts == {}
+    finally:
+        asyncio.run(client.aclose())

--- a/tests/metering/test_regional_rewrite_interop.py
+++ b/tests/metering/test_regional_rewrite_interop.py
@@ -1,0 +1,112 @@
+"""§8.3 "Regional rewrite interop": the metered transport sees the
+POST-rewrite host, for every HTTP method (Task 22 controller: "interop --
+does the conformance suite pass through the REAL client stack (post-rewrite
+hosts)?").
+
+``AuthenticatedClient._inject_headers`` rewrites ``request.url``/``Host``
+to the identity/settings-resolved regional endpoint BEFORE calling
+``super().send()`` (which dispatches through ``self._transport`` --
+the metered transport, when a runtime is active). If the metering wrap
+somehow captured the PRE-rewrite host, this test's requests -- built
+against a deliberately "wrong-region" ``base_url`` -- would raise
+``DisallowedHostError`` (metering.yaml's ``disallowed_host_action:
+reject``, and only the NA host is in ``METERING_UPSTREAM_HOSTS``): the
+absence of that exception, plus each event's recorded host, is the proof.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import set_metering_runtime
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
+
+# The client is constructed against the EU endpoint; with no active
+# identity/marketplace override, `_inject_headers`'s region-routing block
+# falls back to `Settings().amazon_ads_region` -- "na" per
+# tests/conftest.py's autouse `mock_env_vars` -- and rewrites every /v2/
+# request to the NA host BEFORE the transport ever sees it.
+_WRONG_REGION_BASE_URL = "https://advertising-api-eu.amazon.com"
+
+
+def test_all_five_methods_are_metered_against_the_post_rewrite_host(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+            client = AuthenticatedClient(
+                base_url=_WRONG_REGION_BASE_URL,
+                transport=upstream,
+                auth_manager=FakeAuthManager(),
+            )
+            try:
+                methods = ("GET", "POST", "PUT", "PATCH", "DELETE")
+                for method in methods:
+                    response = await client.request(method, "/v2/profiles")
+                    assert response.status_code == 200
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(len(methods))
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        assert len(events) == 5
+        seen_methods = set()
+        for event in events:
+            # Proves the transport saw the POST-rewrite host: had it
+            # observed advertising-api-eu.amazon.com (not in
+            # METERING_UPSTREAM_HOSTS), the request would have raised
+            # DisallowedHostError above instead of reaching here.
+            assert event["data"]["server.address"] == ALLOWED_HOST
+            seen_methods.add(event["data"]["http.request.method"])
+        assert seen_methods == set(("GET", "POST", "PUT", "PATCH", "DELETE"))
+
+    asyncio.run(scenario())
+
+
+def test_wrong_region_base_url_without_rewrite_would_be_rejected(tmp_path) -> None:
+    """Negative control: a path that `_inject_headers` does NOT rewrite
+    (outside /v2/, /reporting/, /amc/) reaches the transport with the
+    ORIGINAL (EU) host still in place, and IS rejected -- proving the
+    metering policy's host allowlist is exact and that the positive test
+    above is genuinely exercising the rewrite, not just an accident of a
+    lenient policy."""
+
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+            client = AuthenticatedClient(
+                base_url=_WRONG_REGION_BASE_URL,
+                transport=upstream,
+                auth_manager=FakeAuthManager(),
+            )
+            try:
+                from mcp_outbound_metering.transport import DisallowedHostError
+
+                with pytest.raises(DisallowedHostError):
+                    await client.get("/not-a-rewritten-path")
+            finally:
+                await client.aclose()
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())

--- a/tests/metering/test_retry_ordinals.py
+++ b/tests/metering/test_retry_ordinals.py
@@ -1,0 +1,137 @@
+"""§8.3 "Retry ordinals": ResilientAuthenticatedClient's retries flow into
+distinct metering events with correct ordinals (Task 22 ruling #6).
+
+Verified-repo-fact correction (brief said "MockTransport scripted
+500,500,200"): ``ResilientAuthenticatedClient.send()`` (see
+``utils/http/resilient_client.py``) wraps ``send_with_retry`` with
+``ResilientRetry`` (``utils/http/resilience.py``), whose retry loop only
+triggers on a raised ``httpx.HTTPStatusError``/``RequestError``/
+``TimeoutException`` -- but ``send_with_retry`` returns
+``super().send(...)`` directly, without ever calling
+``response.raise_for_status()``. A plain 500/503/429 *response* is
+therefore returned on the first attempt with NO retry (verified
+empirically: a MockTransport returning 500,500,200 makes exactly one
+call). This is a pre-existing characteristic of this repo's resilient
+client, orthogonal to Task 22's scope -- not something this task's brief
+asked to change. What genuinely re-invokes ``send_with_retry`` (and thus
+the retry-attribution closure) is a raised transport-level exception, so
+this test scripts ``ConnectError, ConnectError, 200`` instead -- the same
+"three events, retry_attempt 0/1/2, same logical_request_id, distinct
+event ids" assertions the brief specifies, driven the way retries
+actually happen in this codebase today.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import set_metering_runtime
+    from amazon_ads_mcp.utils.http.resilient_client import ResilientAuthenticatedClient
+
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
+
+
+def test_retry_ordinals_flow_into_distinct_events(tmp_path) -> None:
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            calls = {"n": 0}
+
+            def upstream_handler(request: httpx.Request) -> httpx.Response:
+                calls["n"] += 1
+                if calls["n"] < 3:
+                    raise httpx.ConnectError("simulated unreachable upstream", request=request)
+                return httpx.Response(200)
+
+            client = ResilientAuthenticatedClient(
+                transport=httpx.MockTransport(upstream_handler),
+                auth_manager=FakeAuthManager(),
+                interactive_mode=True,
+            )
+            try:
+                request = client.build_request("GET", f"https://{ALLOWED_HOST}/v2/profiles")
+                response = await client.send(request)
+                assert response.status_code == 200
+                assert calls["n"] == 3
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(3)
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        assert len(events) == 3
+
+        ordinals = sorted(e["data"]["mcp.usage.retry_attempt"] for e in events)
+        assert ordinals == [0, 1, 2]
+
+        logical_ids = {e["data"]["mcp.usage.logical_request_id"] for e in events}
+        assert len(logical_ids) == 1  # same logical send across all 3 attempts
+
+        event_ids = {e["id"] for e in events}
+        assert len(event_ids) == 3  # distinct event ids
+
+        outcomes_by_ordinal = {
+            e["data"]["mcp.usage.retry_attempt"]: e["data"]["mcp.usage.outcome"] for e in events
+        }
+        assert outcomes_by_ordinal[0] == "transport_error"
+        assert outcomes_by_ordinal[1] == "transport_error"
+        assert outcomes_by_ordinal[2] == "response"
+
+        is_retry_by_ordinal = {
+            e["data"]["mcp.usage.retry_attempt"]: e["data"].get("mcp.usage.is_retry")
+            for e in events
+        }
+        assert is_retry_by_ordinal == {0: False, 1: True, 2: True}
+
+    asyncio.run(scenario())
+
+
+def test_plain_authenticated_client_send_no_metering_extension(tmp_path) -> None:
+    """Ruling #6: "Production path (plain client) sends no extension." The
+    plain (non-resilient) AuthenticatedClient has no retry loop, so its
+    single send() attaches no request.extensions["metering"] at all --
+    retry_attempt/logical_request_id fall back to None on the resulting
+    event, never a fabricated 0."""
+
+    async def scenario():
+        from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
+        set_metering_runtime(runtime)
+        try:
+            client = AuthenticatedClient(
+                transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+                auth_manager=FakeAuthManager(),
+            )
+            try:
+                request = client.build_request("GET", f"https://{ALLOWED_HOST}/v2/profiles")
+                assert "metering" not in request.extensions
+                response = await client.send(request)
+                assert response.status_code == 200
+            finally:
+                await client.aclose()
+
+            events = await ingest.wait_for_event_count(1)
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+        assert len(events) == 1
+        assert events[0]["data"].get("mcp.usage.retry_attempt") is None
+        assert events[0]["data"].get("mcp.usage.logical_request_id") is None
+
+    asyncio.run(scenario())

--- a/tests/metering/test_server_lifespan_integration.py
+++ b/tests/metering/test_server_lifespan_integration.py
@@ -1,0 +1,77 @@
+"""Integration test for the REAL `server_lifespan()` wiring (Task 22
+ruling #8) -- not just the isolated `metering.lifespan` helper module
+(`test_lifespan.py`), but the actual async context manager
+`server/mcp_server.py` passes to FastMCP.
+
+Verified repo fact (found running the full suite, not just tests/metering
+in isolation): `server/mcp_server.py` module docstring aside, its
+`server_lifespan()` guards the ENTIRE shutdown block (including where
+this task's `stop_metering()` call was added) behind a process-lifetime
+module global, `_cleanup_done`, that is set `True` exactly once and never
+reset -- correct for a real single-process server (shutdown happens once,
+ever), but it means a SECOND `server_lifespan()` invocation in the same
+test process (e.g. another test file's fixture, such as
+`tests/integration/test_inmemory_mcp_client.py`'s `mcp_server` fixture,
+which drives a real FastMCP `Client(...)` startup+shutdown cycle) leaves
+the shutdown block a no-op for every later test that also invokes
+`server_lifespan()` directly, this file included. This is pre-existing
+behavior this task must not change (out of scope, and correct for real
+process lifecycle) -- these tests instead reset `_cleanup_done` to
+`False` via monkeypatch before each scenario, so each one genuinely
+exercises the real shutdown path regardless of test execution order.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from amazon_ads_mcp.metering.adapter import get_metering_runtime
+
+    from ._support import CONFIG_PATH, base_env
+
+
+def test_server_lifespan_starts_and_stops_metering(tmp_path, monkeypatch) -> None:
+    from amazon_ads_mcp.server import mcp_server
+    from amazon_ads_mcp.server.mcp_server import server_lifespan
+
+    monkeypatch.setattr(mcp_server, "_cleanup_done", False)
+
+    env = base_env(tmp_path)
+    env["METERING_CONFIG"] = str(CONFIG_PATH)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    async def scenario():
+        assert get_metering_runtime() is None
+        async with server_lifespan(SimpleNamespace()):
+            assert get_metering_runtime() is not None
+        assert get_metering_runtime() is None
+
+    asyncio.run(scenario())
+
+
+def test_server_lifespan_without_metering_enabled_is_unaffected(monkeypatch) -> None:
+    """The overwhelmingly common case: METERING_ENABLED unset. Lifespan
+    behaves exactly as it did before this integration existed."""
+    from amazon_ads_mcp.server import mcp_server
+    from amazon_ads_mcp.server.mcp_server import server_lifespan
+
+    monkeypatch.setattr(mcp_server, "_cleanup_done", False)
+    monkeypatch.delenv("METERING_ENABLED", raising=False)
+
+    async def scenario():
+        assert get_metering_runtime() is None
+        async with server_lifespan(SimpleNamespace()):
+            assert get_metering_runtime() is None
+        assert get_metering_runtime() is None
+
+    asyncio.run(scenario())

--- a/tests/metering/test_transport_wrap.py
+++ b/tests/metering/test_transport_wrap.py
@@ -1,6 +1,17 @@
-"""§8.3 "Main path": AuthenticatedClient's transport is wrapped IFF a
-metering runtime is active, through both construction paths, and provider
-clients are never touched (Task 22 rulings #3, controller boundary).
+"""§8.3 "Main path": AuthenticatedClient's transport metering is
+timing-independent (fix round 1, CRITICAL), through both construction
+paths, and provider clients are never touched (Task 22 ruling #3,
+controller boundary).
+
+Fix round 1 changed the contract: `client._transport` (and every
+populated `client._mounts` value) is now ALWAYS a `LazyMeteredTransport`,
+regardless of whether a runtime is active at construction time -- the
+actual metering decision is deferred to request time. These tests
+therefore assert the STRUCTURAL wrap (always present) plus the BEHAVIORAL
+outcome (event emitted iff a runtime is active at SEND time), rather than
+asserting `client._transport` is directly a `MeteredAsyncTransport` at
+construction time (see `test_construction_order_independence.py` for the
+dedicated construction-vs-activation-order regression tests).
 """
 
 from __future__ import annotations
@@ -16,17 +27,16 @@ pytestmark = pytest.mark.skipif(
 )
 
 if sys.version_info >= (3, 12):
-    from mcp_outbound_metering.transport import MeteredAsyncTransport
-
     from amazon_ads_mcp.metering.adapter import (
+        LazyMeteredTransport,
         get_metering_runtime,
         install_metered_transport,
         set_metering_runtime,
     )
-    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
     from amazon_ads_mcp.utils.http.client_manager import HTTPClientManager
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
 
-    from ._support import build_runtime
+    from ._support import ALLOWED_HOST, FakeAuthManager, RecordingIngestTransport, build_runtime
 
 
 @pytest.fixture(autouse=True)
@@ -36,25 +46,53 @@ def _reset_metering_runtime():
     set_metering_runtime(None)
 
 
-def test_no_active_runtime_leaves_transport_unwrapped(tmp_path) -> None:
+def test_transport_is_always_lazy_wrapped_even_without_a_runtime() -> None:
+    """Structural: the wrap is unconditional at construction time now --
+    there is no "unwrapped" state for client._transport itself, only for
+    what it delegates to at request time."""
     client = AuthenticatedClient()
     try:
-        assert not isinstance(client._transport, MeteredAsyncTransport)
-        assert isinstance(client._transport, httpx.AsyncHTTPTransport)
+        assert isinstance(client._transport, LazyMeteredTransport)
     finally:
         asyncio.run(client.aclose())
 
 
+def test_no_active_runtime_behaves_unmetered(tmp_path) -> None:
+    """Behavioral: with no active runtime, a request through the
+    LazyMeteredTransport-wrapped client succeeds and emits nothing."""
+
+    async def scenario():
+        ingest = RecordingIngestTransport()
+        upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+        client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+        try:
+            response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+            assert response.status_code == 200
+        finally:
+            await client.aclose()
+        await asyncio.sleep(0.05)
+        assert ingest.events() == []
+
+    asyncio.run(scenario())
+
+
 def test_active_runtime_wraps_direct_construction(tmp_path) -> None:
     async def scenario():
-        runtime = await build_runtime(tmp_path)
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
         set_metering_runtime(runtime)
         try:
-            client = AuthenticatedClient()
+            upstream = httpx.MockTransport(lambda request: httpx.Response(200))
+            client = AuthenticatedClient(transport=upstream, auth_manager=FakeAuthManager())
+            assert isinstance(client._transport, LazyMeteredTransport)
             try:
-                assert isinstance(client._transport, MeteredAsyncTransport)
+                response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+                assert response.status_code == 200
             finally:
                 await client.aclose()
+
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
         finally:
             set_metering_runtime(None)
             await runtime.aclose()
@@ -64,15 +102,24 @@ def test_active_runtime_wraps_direct_construction(tmp_path) -> None:
 
 def test_active_runtime_wraps_http_client_manager_path(tmp_path) -> None:
     async def scenario():
-        runtime = await build_runtime(tmp_path)
+        ingest = RecordingIngestTransport()
+        runtime = await build_runtime(tmp_path, ingest=ingest)
         set_metering_runtime(runtime)
         manager = HTTPClientManager()
         try:
             client = await manager.get_client(
                 client_class=AuthenticatedClient,
+                transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+                auth_manager=FakeAuthManager(),
                 base_url="https://advertising-api.amazon.com/unique-cache-key-1",
             )
-            assert isinstance(client._transport, MeteredAsyncTransport)
+            assert isinstance(client._transport, LazyMeteredTransport)
+
+            response = await client.get(f"https://{ALLOWED_HOST}/v2/profiles")
+            assert response.status_code == 200
+
+            events = await ingest.wait_for_event_count(1)
+            assert len(events) == 1
         finally:
             set_metering_runtime(None)
             await manager.close_all()
@@ -81,11 +128,11 @@ def test_active_runtime_wraps_http_client_manager_path(tmp_path) -> None:
     asyncio.run(scenario())
 
 
-def test_mounts_are_never_wrapped(tmp_path) -> None:
-    """`_mounts` stays exactly what httpx set it to (empty, since no
-    construction path anywhere in this repo passes `mounts=`) --
-    `install_metered_transport` only ever touches the single transport
-    instance handed to it, never `_mounts`."""
+def test_mounts_stay_empty_without_proxy_env(tmp_path) -> None:
+    """`_mounts` stays exactly what httpx set it to -- empty, since no
+    construction path anywhere in this repo passes `mounts=` and no proxy
+    env var is set here. See test_proxy_mounts.py for the populated-mounts
+    case (fix round 1, IMPORTANT)."""
 
     async def scenario():
         runtime = await build_runtime(tmp_path)
@@ -114,7 +161,8 @@ def test_plain_httpx_client_is_never_touched(tmp_path) -> None:
         try:
             client = httpx.AsyncClient()
             try:
-                assert not isinstance(client._transport, MeteredAsyncTransport)
+                assert not isinstance(client._transport, LazyMeteredTransport)
+                assert isinstance(client._transport, httpx.AsyncHTTPTransport)
             finally:
                 await client.aclose()
         finally:
@@ -124,9 +172,16 @@ def test_plain_httpx_client_is_never_touched(tmp_path) -> None:
     asyncio.run(scenario())
 
 
-def test_install_metered_transport_is_pure_pass_through_without_runtime() -> None:
+def test_install_metered_transport_always_wraps_in_lazy_metered_transport() -> None:
+    """Fix round 1: install_metered_transport no longer short-circuits to
+    `inner` unchanged when no runtime is active -- it always returns a
+    LazyMeteredTransport, which itself defers the decision to request
+    time (see test_no_active_runtime_behaves_unmetered above for the
+    behavioral half of this contract)."""
     inner = httpx.AsyncHTTPTransport()
     try:
-        assert install_metered_transport(inner) is inner
+        wrapped = install_metered_transport(inner)
+        assert isinstance(wrapped, LazyMeteredTransport)
+        assert wrapped is not inner
     finally:
         asyncio.run(inner.aclose())

--- a/tests/metering/test_transport_wrap.py
+++ b/tests/metering/test_transport_wrap.py
@@ -1,0 +1,132 @@
+"""§8.3 "Main path": AuthenticatedClient's transport is wrapped IFF a
+metering runtime is active, through both construction paths, and provider
+clients are never touched (Task 22 rulings #3, controller boundary).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="metering requires Python>=3.12"
+)
+
+if sys.version_info >= (3, 12):
+    from mcp_outbound_metering.transport import MeteredAsyncTransport
+
+    from amazon_ads_mcp.metering.adapter import (
+        get_metering_runtime,
+        install_metered_transport,
+        set_metering_runtime,
+    )
+    from amazon_ads_mcp.utils.http_client import AuthenticatedClient
+    from amazon_ads_mcp.utils.http.client_manager import HTTPClientManager
+
+    from ._support import build_runtime
+
+
+@pytest.fixture(autouse=True)
+def _reset_metering_runtime():
+    assert get_metering_runtime() is None
+    yield
+    set_metering_runtime(None)
+
+
+def test_no_active_runtime_leaves_transport_unwrapped(tmp_path) -> None:
+    client = AuthenticatedClient()
+    try:
+        assert not isinstance(client._transport, MeteredAsyncTransport)
+        assert isinstance(client._transport, httpx.AsyncHTTPTransport)
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_active_runtime_wraps_direct_construction(tmp_path) -> None:
+    async def scenario():
+        runtime = await build_runtime(tmp_path)
+        set_metering_runtime(runtime)
+        try:
+            client = AuthenticatedClient()
+            try:
+                assert isinstance(client._transport, MeteredAsyncTransport)
+            finally:
+                await client.aclose()
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_active_runtime_wraps_http_client_manager_path(tmp_path) -> None:
+    async def scenario():
+        runtime = await build_runtime(tmp_path)
+        set_metering_runtime(runtime)
+        manager = HTTPClientManager()
+        try:
+            client = await manager.get_client(
+                client_class=AuthenticatedClient,
+                base_url="https://advertising-api.amazon.com/unique-cache-key-1",
+            )
+            assert isinstance(client._transport, MeteredAsyncTransport)
+        finally:
+            set_metering_runtime(None)
+            await manager.close_all()
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_mounts_are_never_wrapped(tmp_path) -> None:
+    """`_mounts` stays exactly what httpx set it to (empty, since no
+    construction path anywhere in this repo passes `mounts=`) --
+    `install_metered_transport` only ever touches the single transport
+    instance handed to it, never `_mounts`."""
+
+    async def scenario():
+        runtime = await build_runtime(tmp_path)
+        set_metering_runtime(runtime)
+        try:
+            client = AuthenticatedClient()
+            try:
+                assert client._mounts == {}
+            finally:
+                await client.aclose()
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_plain_httpx_client_is_never_touched(tmp_path) -> None:
+    """A plain httpx.AsyncClient (the shape every OAuth/OpenBridge/Kuudo
+    provider client takes) is structurally unaffected by an active
+    runtime -- install_metered_transport is never even called for it."""
+
+    async def scenario():
+        runtime = await build_runtime(tmp_path)
+        set_metering_runtime(runtime)
+        try:
+            client = httpx.AsyncClient()
+            try:
+                assert not isinstance(client._transport, MeteredAsyncTransport)
+            finally:
+                await client.aclose()
+        finally:
+            set_metering_runtime(None)
+            await runtime.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_install_metered_transport_is_pure_pass_through_without_runtime() -> None:
+    inner = httpx.AsyncHTTPTransport()
+    try:
+        assert install_metered_transport(inner) is inner
+    finally:
+        asyncio.run(inner.aclose())

--- a/tests/unit/test_ci_workflows.py
+++ b/tests/unit/test_ci_workflows.py
@@ -100,9 +100,12 @@ def test_dockerfile_copies_in_tree_build_backend_before_project_install():
     text = DOCKERFILE_PATH.read_text()
 
     backend_marker = "build_package.py"
-    project_install_marker = (
-        "uv sync --no-dev --frozen --extra code-mode --no-editable"
-    )
+    # Task 22 fix round 2: the project-install `uv sync` now builds its
+    # --extra set dynamically ($EXTRAS: always code-mode, plus metering
+    # when INCLUDE_METERING=true) rather than a fixed --extra code-mode
+    # literal, so the marker matches the current (parameterized) command
+    # rather than one specific extras combination.
+    project_install_marker = "uv sync --no-dev --frozen $EXTRAS --no-editable"
 
     assert backend_marker in text, (
         "Dockerfile must copy build_package.py before installing the project; "

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,6 @@ dependencies = [
     { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx", extra = ["http2"] },
     { name = "jsonschema" },
-    { name = "mcp-outbound-metering", extra = ["verify"], marker = "python_full_version >= '3.12'" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -44,6 +43,9 @@ audit = [
 ]
 code-mode = [
     { name = "fastmcp", extra = ["code-mode"] },
+]
+metering = [
+    { name = "mcp-outbound-metering", marker = "python_full_version >= '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -67,7 +69,7 @@ requires-dist = [
     { name = "fastmcp", extras = ["tasks"], specifier = ">=3.4.2,<4" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.25.1" },
-    { name = "mcp-outbound-metering", extras = ["verify"], marker = "python_full_version >= '3.12'", git = "https://github.com/KuudoAI/billing?subdirectory=packages%2Fpython%2Fmcp_outbound_metering&rev=ef8f71ee722c35265050c38fb34f9a9ea36122da" },
+    { name = "mcp-outbound-metering", marker = "python_full_version >= '3.12' and extra == 'metering'", git = "https://github.com/KuudoAI/billing?subdirectory=packages%2Fpython%2Fmcp_outbound_metering&rev=ef8f71ee722c35265050c38fb34f9a9ea36122da" },
     { name = "openai", specifier = ">=1.109.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -78,7 +80,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "tiktoken", marker = "extra == 'audit'", specifier = ">=0.7.0" },
 ]
-provides-extras = ["audit", "code-mode"]
+provides-extras = ["audit", "code-mode", "metering"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1300,11 +1302,6 @@ dependencies = [
     { name = "httpx", marker = "python_full_version >= '3.12'" },
     { name = "jsonschema", marker = "python_full_version >= '3.12'" },
     { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-]
-
-[package.optional-dependencies]
-verify = [
-    { name = "pytest", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10, <4.0"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "aiofile"
@@ -16,13 +20,14 @@ wheels = [
 
 [[package]]
 name = "amazon-ads-mcp"
-version = "0.3.25"
+version = "0.3.27"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx", extra = ["http2"] },
     { name = "jsonschema" },
+    { name = "mcp-outbound-metering", extra = ["verify"], marker = "python_full_version >= '3.12'" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -62,6 +67,7 @@ requires-dist = [
     { name = "fastmcp", extras = ["tasks"], specifier = ">=3.4.2,<4" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.25.1" },
+    { name = "mcp-outbound-metering", extras = ["verify"], marker = "python_full_version >= '3.12'", git = "https://github.com/KuudoAI/billing?subdirectory=packages%2Fpython%2Fmcp_outbound_metering&rev=ef8f71ee722c35265050c38fb34f9a9ea36122da" },
     { name = "openai", specifier = ">=1.109.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -1287,6 +1293,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp-outbound-metering"
+version = "0.1.0.dev0"
+source = { git = "https://github.com/KuudoAI/billing?subdirectory=packages%2Fpython%2Fmcp_outbound_metering&rev=ef8f71ee722c35265050c38fb34f9a9ea36122da#ef8f71ee722c35265050c38fb34f9a9ea36122da" }
+dependencies = [
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+]
+
+[package.optional-dependencies]
+verify = [
+    { name = "pytest", marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2404,8 +2425,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Integrates the KuudoAI/billing metering platform's producer runtime: every Amazon Ads API call (all OpenAPI mounts, the profile-listing secondary client, and resilient-client retries) is metered at the httpx transport layer; auth/OAuth/provider and S3 download traffic is structurally excluded.

- **Timing-independent seam**: `AuthenticatedClient` always installs a `LazyMeteredTransport` (on `_transport` and every proxy mount) that consults the active `MeteringRuntime` per request — the wrap cannot be defeated by construction order (regression-tested against the real `ServerBuilder.build()` → `server_lifespan()` boot sequence) or by `HTTP(S)_PROXY` mounts.
- **Dimensions**: identity_id, profile_id, region, auth_method, and a new `tool_name` ContextVar (FastMCP middleware + the Code Mode `bridged_call_tool` bypass path). Retry ordinals flow via the `"metering"` request extension in `ResilientAuthenticatedClient`.
- **Lifecycle**: runtime starts in `server_lifespan()` after auth validation and flushes/closes before client-manager shutdown; `/health` gains a `metering` section. Strict `METERING_ENABLED=true` fails startup on unsupported runtimes (billing-critical).
- **Compatibility**: dependency carries a `python_version >= '3.12'` marker with a loud degraded-mode guard; the full existing suite is unchanged-green on 3.10 (same lone pre-existing Hypothesis failure).
- **CI**: new 3.12-only `metering` job running the suite + `mcp-metering verify` conformance.

## Tests

80 metering tests on 3.12 (incl. boot-order + proxy-mount regressions, 11/11 conformance through the real client stack); existing suite untouched on 3.10; `mcp-metering verify` exit 0. Two independent review rounds with reproduction-based verification.

## Operator gates before enabling in production

1. Provision the `BILLING_REPO_TOKEN` CI secret (private billing repo dependency).
2. Set `METERING_UPSTREAM_HOSTS` to all three regional hosts (`advertising-api.amazon.com`, `-eu`, `-fe`; `-test` variants for sandbox) — reject-mode breaks EU/FE traffic otherwise.
3. Confirm the deployment runtime is Python ≥ 3.12 (metering is a no-op below).

## Pre-existing issues found during integration (not addressed here)

- `ResilientAuthenticatedClient` does not retry on HTTP status codes (retry predicate only catches raised exceptions; plain 5xx responses return on attempt 1).
- `schema_normalization._normalize_key` is non-idempotent for Turkish dotted-İ input (Hypothesis failure on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)