### PR TITLE
fix: clear Kuudo tenant state on bearer swaps

### DIFF
--- a/docs/superpowers/plans/2026-07-22-kuudo-session-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-22-kuudo-session-reconciliation.md
@@ -1,0 +1,122 @@
+# Kuudo Session Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve a freshly selected Kuudo identity for credential loading and prevent code-mode nested calls from rehydrating stale tenant state.
+
+**Architecture:** Treat the provider-derived request fingerprint as the authoritative request ownership signal. Centralize session hydration plus reconciliation so both normal middleware and code-mode nested dispatch apply the same tenant boundary before executing tools.
+
+**Tech Stack:** Python 3.10+, ContextVars, FastMCP session state, pytest, Ruff, uv.
+
+## Global Constraints
+
+- Never persist or expose the raw Kuudo API key.
+- Preserve the existing auth-provider pattern and provider-independent session bridge.
+- Clear identity, credentials, and profiles on a fingerprint mismatch before downstream tool execution.
+- Follow red-green TDD for both regressions.
+
+---
+
+### Task 1: Preserve Kuudo identity during initial credential fetch
+
+**Files:**
+- Modify: `tests/unit/test_auth_manager_advanced.py`
+- Modify: `src/amazon_ads_mcp/auth/session_state.py`
+- Modify: `src/amazon_ads_mcp/auth/manager.py`
+
+**Interfaces:**
+- Consumes: the fingerprint bound by `bind_request_tenant_fingerprint(fingerprint)`.
+- Produces: `get_request_tenant_fingerprint() -> Optional[str]` for provider-neutral ownership checks.
+
+- [ ] **Step 1: Write a failing test**
+
+Add a Kuudo-style multi-identity provider test that binds a request fingerprint,
+sets the same last-seen fingerprint, selects an identity without session
+credentials, and asserts `get_active_credentials()` fetches that identity's
+credentials without clearing it.
+
+- [ ] **Step 2: Verify the red state**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_auth_manager_advanced.py -k request_fingerprint_preserves_selected_identity -v
+```
+
+Expected: FAIL because the guard clears the selected identity when no refresh-token override or loaded credentials exist.
+
+- [ ] **Step 3: Implement the minimal ownership check**
+
+Expose the bound request fingerprint from `session_state.py`. In
+`AuthManager.get_active_credentials()`, compare it with
+`last_seen_token_fingerprint` before the legacy refresh-token checks. Preserve
+the identity on equality and clear it on mismatch.
+
+- [ ] **Step 4: Verify the green state**
+
+Run the command from Step 2. Expected: PASS.
+
+### Task 2: Reconcile every code-mode bridge hydration
+
+**Files:**
+- Modify: `tests/unit/test_code_mode.py`
+- Modify: `src/amazon_ads_mcp/middleware/auth_session_bridge.py`
+- Modify: `src/amazon_ads_mcp/middleware/authentication.py`
+- Modify: `src/amazon_ads_mcp/server/code_mode.py`
+
+**Interfaces:**
+- Produces: `hydrate_and_reconcile_auth_from_mcp_session(context, logger_instance=None) -> bool`, returning whether tenant state was cleared.
+
+- [ ] **Step 1: Write a failing test**
+
+Seed parent session state with tenant A identity, credentials, profiles, and
+fingerprint. Bind tenant B's request fingerprint, execute a bridged nested tool,
+and assert the tool observes no tenant A state.
+
+- [ ] **Step 2: Verify the red state**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_code_mode.py -k bearer_swap -v
+```
+
+Expected: FAIL because `AuthBridgingSandboxProvider` hydrates tenant A without reconciliation.
+
+- [ ] **Step 3: Implement shared hydrate-and-reconcile**
+
+Add the shared helper to `auth_session_bridge.py`, use it from
+`AuthSessionStateMiddleware`, and use it immediately before every nested
+code-mode tool dispatch.
+
+- [ ] **Step 4: Verify the green state**
+
+Run the command from Step 2. Expected: PASS.
+
+### Task 3: Repository verification and publication
+
+**Files:**
+- Verify all files modified in Tasks 1 and 2.
+
+**Interfaces:**
+- Consumes: the two passing regression tests.
+- Produces: a validated commit on PR #100.
+
+- [ ] **Step 1: Run focused auth and code-mode tests**
+
+```bash
+uv run pytest tests/unit/test_auth_manager_advanced.py tests/unit/test_session_state.py tests/unit/test_auth_session_bridge.py tests/unit/test_authentication_middleware.py tests/unit/test_inbound_auth.py tests/unit/test_kuudo_provider.py tests/unit/test_code_mode.py tests/integration/test_code_mode_nested_auth.py
+```
+
+- [ ] **Step 2: Run required repository validation in sequence**
+
+```bash
+uv sync
+uv run ruff check --fix
+uv run pytest
+```
+
+- [ ] **Step 3: Review and publish the focused diff**
+
+Inspect `git diff`, commit with a focused Conventional Commit message, push the
+existing PR branch, and inspect PR #100 checks and unresolved review threads.

--- a/docs/superpowers/specs/2026-07-22-kuudo-session-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-22-kuudo-session-reconciliation-design.md
@@ -1,0 +1,50 @@
+# Kuudo Session Reconciliation Design
+
+## Problem
+
+Kuudo binds each HTTP request to a provider-derived API-key fingerprint before
+the MCP middleware chain runs. Two paths currently lose that binding:
+
+1. `AuthManager.get_active_credentials()` recognizes refresh-token state but
+   does not recognize the provider-derived request fingerprint. A freshly
+   selected Kuudo identity therefore looks unverifiable before its credentials
+   have been loaded and is cleared.
+2. Code-mode nested `call_tool` dispatch hydrates the parent MCP session after
+   the outer request has reconciled a bearer swap. Because the nested path does
+   not reconcile after hydration, it can restore the previous tenant's state.
+
+## Design
+
+Expose the current request's already-derived tenant fingerprint through a
+read-only session-state accessor. The credential guard will compare that value
+with the persisted last-seen fingerprint before consulting provider-specific
+fallback channels. Equality proves that the active identity belongs to the
+current request, including the period before credentials have been fetched.
+
+Add a shared `hydrate_and_reconcile_auth_from_mcp_session()` helper. It will
+hydrate ContextVars and immediately reconcile them against the current request
+fingerprint. Both normal request middleware and code-mode nested dispatch will
+use this operation so no caller can hydrate tenant state without applying the
+same ownership check before downstream execution.
+
+The raw Kuudo API key remains provider-local. Session persistence continues to
+contain only the derived fingerprint. Direct and OpenBridge behavior remains
+unchanged when no provider-derived request fingerprint is bound.
+
+## Error Handling
+
+A mismatched or previously unbound session is cleared with the existing
+`token_swapped` reset reason. A matching request fingerprint preserves the
+selected identity and permits normal credential loading. Hydration failures
+retain the existing fail-safe reset behavior before reconciliation binds the
+current request fingerprint.
+
+## Testing
+
+- Reproduce a fresh multi-identity Kuudo selection with a matching request
+  fingerprint and no preloaded credentials; credential fetch must retain the
+  selected identity.
+- Reproduce code-mode hydration of tenant A while tenant B is bound to the
+  outer request; the nested tool must observe cleared identity, credentials,
+  and profiles before it executes.
+- Run focused auth tests, Ruff, and the full pytest suite.

--- a/src/amazon_ads_mcp/auth/manager.py
+++ b/src/amazon_ads_mcp/auth/manager.py
@@ -26,6 +26,7 @@ from .session_state import (
     get_active_identity as _ctx_get_identity,
     get_active_profiles as _ctx_get_profiles,
     get_last_seen_token_fingerprint,
+    get_request_tenant_fingerprint,
     get_refresh_token_override,
     reset_session_state,
     set_active_credentials as _ctx_set_credentials,
@@ -493,18 +494,29 @@ class AuthManager:
             # Even if the middleware cleared state on token change, this guard
             # catches races, middleware ordering issues, and future regressions.
             #
-            # Two cases trigger invalidation:
-            #   1. Token present but fingerprint differs from last_seen
+            # Three cases trigger invalidation:
+            #   1. A provider-derived request fingerprint differs from last_seen
+            #      or has no prior session binding.
+            #   2. Token present but fingerprint differs from last_seen
             #      → mid-session tenant swap.
-            #   2. No token on this request but last_seen fingerprint exists
+            #   3. No token on this request but last_seen fingerprint exists
             #      → identity was established under a specific token we can
             #        no longer verify; clear to prevent silent reuse.
             if active_identity:
+                request_fp = get_request_tenant_fingerprint()
                 current_token = get_refresh_token_override()
                 last_fp = get_last_seen_token_fingerprint()
 
                 should_clear = False
-                if current_token:
+                if request_fp is not None:
+                    if last_fp != request_fp:
+                        should_clear = True
+                        logger.warning(
+                            "Request tenant fingerprint mismatches session state — "
+                            "clearing stale tenant state (identity=%s)",
+                            active_identity.id,
+                        )
+                elif current_token:
                     current_fp = token_fingerprint(current_token)
                     if last_fp and current_fp != last_fp:
                         should_clear = True

--- a/src/amazon_ads_mcp/auth/providers/kuudo.py
+++ b/src/amazon_ads_mcp/auth/providers/kuudo.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
-import hmac
 import json
 import os
 import secrets
@@ -152,10 +151,13 @@ class KuudoAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
             "kuudo_current_api_key",
             default=None,
         )
+        self._current_api_key_fingerprint: ContextVar[str | None] = ContextVar(
+            "kuudo_current_api_key_fingerprint",
+            default=None,
+        )
         self._client: httpx.AsyncClient | None = self.config.http_client
         self._owns_client = self.config.http_client is None
         self._fingerprint_salt = secrets.token_bytes(32)
-        self._session_fingerprint_key = secrets.token_bytes(32)
         self._configured_api_key_fingerprint: str | None = None
         self._configured_api_key_fingerprint_lock = asyncio.Lock()
         self._tokens: OrderedDict[str, Token] = OrderedDict()
@@ -352,13 +354,20 @@ class KuudoAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
 
         return self._current_api_key.set(api_key)
 
-    def session_api_key_fingerprint(self, api_key: str) -> str:
-        """Return a provider-local session discriminator for an API key."""
-        return hmac.new(
-            self._session_fingerprint_key,
-            api_key.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
+    async def session_api_key_fingerprint(self, api_key: str) -> str:
+        """Return the provider-local PBKDF2 discriminator for an API key."""
+        return await self._fingerprint_for(api_key)
+
+    def set_current_api_key_fingerprint(
+        self, fingerprint: str
+    ) -> ContextToken[str | None]:
+        """Set a derived API-key fingerprint for the current async context."""
+        return self._current_api_key_fingerprint.set(fingerprint)
+
+    def reset_current_api_key_fingerprint(
+        self, token: ContextToken[str | None]
+    ) -> None:
+        self._current_api_key_fingerprint.reset(token)
 
     def reset_current_api_key(self, token: ContextToken[str | None]) -> None:
         self._current_api_key.reset(token)
@@ -458,6 +467,15 @@ class KuudoAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         ).hex()
 
     async def _fingerprint_for(self, value: str) -> str:
+        current_api_key = self._current_api_key.get()
+        current_fingerprint = self._current_api_key_fingerprint.get()
+        if (
+            current_api_key
+            and current_fingerprint
+            and secrets.compare_digest(value, current_api_key)
+        ):
+            return current_fingerprint
+
         if value != self.config.api_key:
             return await asyncio.to_thread(self._fingerprint, value)
 

--- a/src/amazon_ads_mcp/auth/providers/kuudo.py
+++ b/src/amazon_ads_mcp/auth/providers/kuudo.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import hmac
 import json
 import os
 import secrets
@@ -154,6 +155,7 @@ class KuudoAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         self._client: httpx.AsyncClient | None = self.config.http_client
         self._owns_client = self.config.http_client is None
         self._fingerprint_salt = secrets.token_bytes(32)
+        self._session_fingerprint_key = secrets.token_bytes(32)
         self._configured_api_key_fingerprint: str | None = None
         self._configured_api_key_fingerprint_lock = asyncio.Lock()
         self._tokens: OrderedDict[str, Token] = OrderedDict()
@@ -349,6 +351,14 @@ class KuudoAmazonAdsProvider(BaseAmazonAdsProvider, BaseIdentityProvider):
         """Set an API-key override for the current async context."""
 
         return self._current_api_key.set(api_key)
+
+    def session_api_key_fingerprint(self, api_key: str) -> str:
+        """Return a provider-local session discriminator for an API key."""
+        return hmac.new(
+            self._session_fingerprint_key,
+            api_key.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
 
     def reset_current_api_key(self, token: ContextToken[str | None]) -> None:
         self._current_api_key.reset(token)

--- a/src/amazon_ads_mcp/auth/session_state.py
+++ b/src/amazon_ads_mcp/auth/session_state.py
@@ -168,6 +168,11 @@ def set_last_seen_token_fingerprint(fingerprint: Optional[str]) -> None:
     _last_seen_token_fingerprint_var.set(fingerprint)
 
 
+def get_request_tenant_fingerprint() -> Optional[str]:
+    """Return the provider-derived fingerprint bound to this request."""
+    return _request_token_fingerprint_var.get()
+
+
 def bind_request_tenant_fingerprint(
     fingerprint: str,
 ) -> ContextToken[Optional[str]]:

--- a/src/amazon_ads_mcp/auth/session_state.py
+++ b/src/amazon_ads_mcp/auth/session_state.py
@@ -13,15 +13,19 @@ All defaults are ``None`` to avoid shared mutable state. The profiles
 accessor returns an empty dict when the underlying var is ``None``.
 
 Token change detection:
-- ``_last_seen_token_fingerprint_var`` tracks the SHA-256 fingerprint
-  of the last refresh token seen in this session. Unlike other ContextVars,
-  it is NOT cleared per-request — it persists across tool calls so the
-  middleware can detect when a different tenant token arrives and invalidate
-  stale identity/credential/profile state.
+- ``_last_seen_token_fingerprint_var`` tracks a provider-appropriate
+  fingerprint of the last tenant-scoping token seen in this session. Unlike
+  other ContextVars, it is NOT cleared per-request — it persists across tool
+  calls so middleware can detect when a different tenant token arrives and
+  invalidate stale identity/credential/profile state. Kuudo supplies a
+  provider-instance-keyed discriminator; raw API keys never enter this state.
+- ``_request_token_fingerprint_var`` carries the current request's
+  fingerprint across middleware ordering boundaries. Its owner must restore
+  the returned ContextVar token in a ``finally`` block.
 """
 
 import hashlib
-from contextvars import ContextVar
+from contextvars import ContextVar, Token as ContextToken
 from typing import Dict, Optional
 
 from ..models import AuthCredentials, Identity
@@ -52,12 +56,15 @@ _last_seen_token_fingerprint_var: ContextVar[Optional[str]] = ContextVar(
     "last_seen_token_fingerprint", default=None
 )
 
+_request_token_fingerprint_var: ContextVar[Optional[str]] = ContextVar(
+    "request_token_fingerprint", default=None
+)
+
 # Per-request: explains why tenant state was just cleared (or why
 # state would not be session-sticky). Read by tool wrappers via
 # ``compute_session_state`` to populate the ``state_reason`` field
-# on responses. Set by ``RefreshTokenMiddleware`` on token swap and
-# cleared in its ``finally`` block so it does not leak across
-# requests.
+# on responses. Set by tenant-token reconciliation on token swap and
+# cleared by request auth middleware so it does not leak across requests.
 _state_reset_reason_var: ContextVar[Optional[str]] = ContextVar(
     "state_reset_reason", default=None
 )
@@ -143,7 +150,7 @@ def set_refresh_token_override(token: Optional[str]) -> None:
 
 
 def token_fingerprint(token: str) -> str:
-    """Compute SHA-256 fingerprint for a refresh token.
+    """Compute a SHA-256 fingerprint for a tenant-scoping token.
 
     Consistent with ``OpenBridgeAuthProvider._token_fingerprint()`` so the
     same token produces the same digest everywhere.
@@ -152,13 +159,74 @@ def token_fingerprint(token: str) -> str:
 
 
 def get_last_seen_token_fingerprint() -> Optional[str]:
-    """Return the fingerprint of the last refresh token seen in this session."""
+    """Return the last tenant-token fingerprint seen in this session."""
     return _last_seen_token_fingerprint_var.get()
 
 
 def set_last_seen_token_fingerprint(fingerprint: Optional[str]) -> None:
-    """Set the fingerprint of the last refresh token seen in this session."""
+    """Set the last tenant-token fingerprint seen in this session."""
     _last_seen_token_fingerprint_var.set(fingerprint)
+
+
+def bind_request_tenant_fingerprint(
+    fingerprint: str,
+) -> ContextToken[Optional[str]]:
+    """Bind a tenant fingerprint to the current middleware context.
+
+    The provider derives the discriminator before calling this function, so
+    the raw tenant token never enters session persistence. Callers must pass
+    the returned token to :func:`reset_request_tenant_token` in a ``finally``
+    block.
+    """
+    return _request_token_fingerprint_var.set(fingerprint)
+
+
+def reset_request_tenant_token(token: ContextToken[Optional[str]]) -> None:
+    """Restore the previous request tenant-token fingerprint."""
+    _request_token_fingerprint_var.reset(token)
+
+
+def reconcile_request_tenant_state() -> bool:
+    """Bind hydrated tenant state to the current request's token.
+
+    Returns ``True`` when existing tenant state was cleared. State without a
+    prior fingerprint is also cleared before binding: it may have been
+    persisted by a version that did not fingerprint this provider's bearer,
+    so preserving it would silently assign unknown credentials to the current
+    caller.
+    """
+    new_fp = _request_token_fingerprint_var.get()
+    if new_fp is None:
+        return False
+
+    return _reconcile_tenant_state(new_fp)
+
+
+def reconcile_tenant_state_for_token(token: str) -> bool:
+    """Reconcile hydrated tenant state against a raw request token."""
+    return _reconcile_tenant_state(token_fingerprint(token))
+
+
+def _reconcile_tenant_state(new_fp: str) -> bool:
+    """Clear tenant state when ``new_fp`` does not own hydrated state."""
+
+    previous_fp = get_last_seen_token_fingerprint()
+    has_unbound_state = (
+        get_active_identity() is not None
+        or get_active_credentials() is not None
+        or bool(get_active_profiles())
+    )
+    token_changed = previous_fp is not None and previous_fp != new_fp
+    unbound_state = previous_fp is None and has_unbound_state
+
+    if token_changed or unbound_state:
+        set_active_identity(None)
+        set_active_credentials(None)
+        set_active_profiles(None)
+        set_state_reset_reason("token_swapped")
+
+    set_last_seen_token_fingerprint(new_fp)
+    return token_changed or unbound_state
 
 
 # ---------------------------------------------------------------------------
@@ -169,8 +237,8 @@ def set_last_seen_token_fingerprint(fingerprint: Optional[str]) -> None:
 def get_state_reset_reason() -> Optional[str]:
     """Return the reason tenant state was just cleared, if any.
 
-    Set by ``RefreshTokenMiddleware`` when it detects a mid-session
-    token swap (value: ``"token_swapped"``) and cleared in the
+    Set by tenant-token reconciliation when it detects a mid-session token
+    swap (value: ``"token_swapped"``) and cleared by the request auth
     middleware's ``finally`` block. Tool wrappers read this via
     :func:`amazon_ads_mcp.middleware.auth_session_bridge.compute_session_state`
     to populate the ``state_reason`` response field so agent clients
@@ -205,7 +273,24 @@ def reset_session_state() -> None:
     _active_credentials_var.set(None)
     _active_profiles_var.set(None)
     _refresh_token_override_var.set(None)
+    _request_token_fingerprint_var.set(None)
     _state_reset_reason_var.set(None)
+
+
+def reset_hydrated_session_state() -> None:
+    """Clear hydrated auth state while preserving current request binding.
+
+    Session hydration uses this when no saved state exists or state loading
+    fails. The request-token fingerprint may already have been bound by an
+    outer authorization middleware and must remain available for
+    reconciliation after hydration.
+    """
+    _active_identity_var.set(None)
+    _active_credentials_var.set(None)
+    _active_profiles_var.set(None)
+    _refresh_token_override_var.set(None)
+    _state_reset_reason_var.set(None)
+    _last_seen_token_fingerprint_var.set(None)
 
 
 def reset_all_session_state() -> None:

--- a/src/amazon_ads_mcp/middleware/auth_session_bridge.py
+++ b/src/amazon_ads_mcp/middleware/auth_session_bridge.py
@@ -15,7 +15,7 @@ from ..auth.session_state import (
     get_active_profiles,
     get_last_seen_token_fingerprint,
     get_state_reset_reason,
-    reset_all_session_state,
+    reset_hydrated_session_state,
     set_active_credentials,
     set_active_identity,
     set_active_profiles,
@@ -88,7 +88,7 @@ async def hydrate_auth_from_mcp_session(
     try:
         state = await fastmcp_context.get_state(AUTH_SESSION_STATE_KEY)
         if not state or not isinstance(state, dict):
-            reset_all_session_state()
+            reset_hydrated_session_state()
             return
 
         identity_payload = state.get("active_identity")
@@ -129,7 +129,7 @@ async def hydrate_auth_from_mcp_session(
             except Exception as region_exc:
                 log.debug("Failed to hydrate active region: %s", region_exc)
     except Exception as exc:
-        reset_all_session_state()
+        reset_hydrated_session_state()
         log.warning("Failed to hydrate auth session state: %s", exc)
 
 

--- a/src/amazon_ads_mcp/middleware/auth_session_bridge.py
+++ b/src/amazon_ads_mcp/middleware/auth_session_bridge.py
@@ -15,6 +15,7 @@ from ..auth.session_state import (
     get_active_profiles,
     get_last_seen_token_fingerprint,
     get_state_reset_reason,
+    reconcile_request_tenant_state,
     reset_hydrated_session_state,
     set_active_credentials,
     set_active_identity,
@@ -131,6 +132,14 @@ async def hydrate_auth_from_mcp_session(
     except Exception as exc:
         reset_hydrated_session_state()
         log.warning("Failed to hydrate auth session state: %s", exc)
+
+
+async def hydrate_and_reconcile_auth_from_mcp_session(
+    fastmcp_context: Any, logger_instance: Optional[logging.Logger] = None
+) -> bool:
+    """Hydrate session auth state and bind it to the current request tenant."""
+    await hydrate_auth_from_mcp_session(fastmcp_context, logger_instance)
+    return reconcile_request_tenant_state()
 
 
 async def persist_auth_to_mcp_session(

--- a/src/amazon_ads_mcp/middleware/authentication.py
+++ b/src/amazon_ads_mcp/middleware/authentication.py
@@ -50,6 +50,7 @@ import jwt
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
+from ..auth.session_state import reconcile_request_tenant_state
 from ..utils.http import get_http_client
 from ..utils.security import sanitize_string
 from .auth_session_bridge import (
@@ -599,34 +600,15 @@ class RefreshTokenMiddleware(Middleware):
                 # vars hold stale tenant state. Detect the swap via fingerprint
                 # and clear tenant-scoped state before proceeding.
                 from ..auth.session_state import (
-                    get_last_seen_token_fingerprint,
-                    set_active_credentials,
-                    set_active_identity,
-                    set_active_profiles,
-                    set_last_seen_token_fingerprint,
+                    reconcile_tenant_state_for_token,
                     set_refresh_token_override,
-                    set_state_reset_reason,
-                    token_fingerprint,
                 )
 
-                new_fp = token_fingerprint(token)
-                previous_fp = get_last_seen_token_fingerprint()
-
-                if previous_fp and previous_fp != new_fp:
+                if reconcile_tenant_state_for_token(token):
                     self.logger.info(
                         "Refresh token changed mid-session — "
                         "clearing tenant identity/credentials/profiles"
                     )
-                    set_active_identity(None)
-                    set_active_credentials(None)
-                    set_active_profiles(None)
-                    # Surface the reset reason to tool wrappers so the
-                    # ``state_reason`` response field tells agents to
-                    # re-establish context. Cleared in the finally
-                    # block below so it does not leak across requests.
-                    set_state_reset_reason("token_swapped")
-
-                set_last_seen_token_fingerprint(new_fp)
 
                 # Set per-request ContextVar for session isolation.
                 # We intentionally do NOT call provider.set_refresh_token()
@@ -824,6 +806,11 @@ class AuthSessionStateMiddleware(Middleware):
     async def on_request(self, context: MiddlewareContext, call_next):
         fastmcp_context = getattr(context, "fastmcp_context", None)
         await self._hydrate(fastmcp_context)
+        if reconcile_request_tenant_state():
+            self.logger.info(
+                "Tenant token changed mid-session — clearing "
+                "identity/credentials/profiles"
+            )
         try:
             return await call_next(context)
         finally:

--- a/src/amazon_ads_mcp/middleware/authentication.py
+++ b/src/amazon_ads_mcp/middleware/authentication.py
@@ -50,13 +50,12 @@ import jwt
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
-from ..auth.session_state import reconcile_request_tenant_state
 from ..utils.http import get_http_client
 from ..utils.security import sanitize_string
 from .auth_session_bridge import (
     AUTH_SESSION_STATE_KEY as BRIDGE_AUTH_SESSION_STATE_KEY,
     has_auth_session,
-    hydrate_auth_from_mcp_session,
+    hydrate_and_reconcile_auth_from_mcp_session,
     persist_auth_to_mcp_session,
 )
 
@@ -793,8 +792,8 @@ class AuthSessionStateMiddleware(Middleware):
         """
         return has_auth_session(fastmcp_context)
 
-    async def _hydrate(self, fastmcp_context: Any) -> None:
-        await hydrate_auth_from_mcp_session(
+    async def _hydrate(self, fastmcp_context: Any) -> bool:
+        return await hydrate_and_reconcile_auth_from_mcp_session(
             fastmcp_context, logger_instance=self.logger
         )
 
@@ -805,8 +804,7 @@ class AuthSessionStateMiddleware(Middleware):
 
     async def on_request(self, context: MiddlewareContext, call_next):
         fastmcp_context = getattr(context, "fastmcp_context", None)
-        await self._hydrate(fastmcp_context)
-        if reconcile_request_tenant_state():
+        if await self._hydrate(fastmcp_context):
             self.logger.info(
                 "Tenant token changed mid-session — clearing "
                 "identity/credentials/profiles"

--- a/src/amazon_ads_mcp/server/code_mode.py
+++ b/src/amazon_ads_mcp/server/code_mode.py
@@ -30,7 +30,7 @@ from fastmcp.server.dependencies import get_context
 from ..config.settings import settings
 from ._polling_guidance import SANDBOX_POLLING_GUIDANCE
 from ..middleware.auth_session_bridge import (
-    hydrate_auth_from_mcp_session,
+    hydrate_and_reconcile_auth_from_mcp_session,
     persist_auth_to_mcp_session,
 )
 
@@ -485,9 +485,16 @@ class AuthBridgingSandboxProvider:
                 from .sidecar_middleware import apply_sidecar_input_transforms
 
                 async with call_lock:
-                    await hydrate_auth_from_mcp_session(
-                        parent_ctx, logger_instance=logger
+                    tenant_state_cleared = (
+                        await hydrate_and_reconcile_auth_from_mcp_session(
+                            parent_ctx, logger_instance=logger
+                        )
                     )
+                    if tenant_state_cleared:
+                        logger.info(
+                            "Tenant token changed before nested code-mode call — "
+                            "clearing identity/credentials/profiles"
+                        )
                     try:
                         rewritten = await apply_sidecar_input_transforms(
                             name, params or {}

--- a/src/amazon_ads_mcp/server/inbound_auth.py
+++ b/src/amazon_ads_mcp/server/inbound_auth.py
@@ -265,14 +265,19 @@ class InboundHTTPAuthMiddleware(Middleware):
         if result.reason != "kuudo_bearer" or not bearer:
             return await call_next(context)
 
+        fingerprint = await provider.session_api_key_fingerprint(bearer)
         api_key_context_token = provider.set_current_api_key(bearer)
+        fingerprint_context_token = provider.set_current_api_key_fingerprint(
+            fingerprint
+        )
         tenant_context_token = bind_request_tenant_fingerprint(
-            provider.session_api_key_fingerprint(bearer)
+            fingerprint
         )
         try:
             return await call_next(context)
         finally:
             reset_request_tenant_token(tenant_context_token)
+            provider.reset_current_api_key_fingerprint(fingerprint_context_token)
             provider.reset_current_api_key(api_key_context_token)
             set_state_reset_reason(None)
 

--- a/src/amazon_ads_mcp/server/inbound_auth.py
+++ b/src/amazon_ads_mcp/server/inbound_auth.py
@@ -19,6 +19,11 @@ from starlette.middleware import Middleware as StarletteMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+from ..auth.session_state import (
+    bind_request_tenant_fingerprint,
+    reset_request_tenant_token,
+    set_state_reset_reason,
+)
 from ..exceptions import AuthenticationError
 from ..middleware.error_envelope import build_envelope_from_exception, envelope_to_json
 
@@ -210,7 +215,6 @@ def authorize_inbound_http(
         return InboundAuthResult(
             True,
             "kuudo_bearer",
-            token_fingerprint=token_fingerprint(bearer),
         )
     if provider_type == "direct" and request_is_loopback(request, configured_host):
         return InboundAuthResult(True, "direct_loopback")
@@ -261,11 +265,16 @@ class InboundHTTPAuthMiddleware(Middleware):
         if result.reason != "kuudo_bearer" or not bearer:
             return await call_next(context)
 
-        context_token = provider.set_current_api_key(bearer)
+        api_key_context_token = provider.set_current_api_key(bearer)
+        tenant_context_token = bind_request_tenant_fingerprint(
+            provider.session_api_key_fingerprint(bearer)
+        )
         try:
             return await call_next(context)
         finally:
-            provider.reset_current_api_key(context_token)
+            reset_request_tenant_token(tenant_context_token)
+            provider.reset_current_api_key(api_key_context_token)
+            set_state_reset_reason(None)
 
     async def on_request(self, context: MiddlewareContext, call_next: Any) -> Any:
         method = getattr(context, "method", None)

--- a/tests/unit/test_auth_manager_advanced.py
+++ b/tests/unit/test_auth_manager_advanced.py
@@ -66,6 +66,12 @@ class DirectIdentityProvider(MultiIdentityProvider):
         return "direct"
 
 
+class KuudoIdentityProvider(MultiIdentityProvider):
+    @property
+    def provider_type(self) -> str:
+        return "kuudo"
+
+
 class SingleIdentityProvider(BaseAmazonAdsProvider):
     def __init__(self, token_value="single-token"):
         self._token = Token(
@@ -459,6 +465,41 @@ class TestCredentialsFingerprintGuard:
         # Identity preserved, credentials returned
         assert get_active_identity() is identity
         assert creds.identity_id == "id-a"
+
+    @pytest.mark.asyncio
+    async def test_request_fingerprint_preserves_selected_identity(
+        self, auth_manager
+    ):
+        """A bound provider fingerprint permits initial credential loading."""
+        from amazon_ads_mcp.auth.session_state import (
+            bind_request_tenant_fingerprint,
+            get_active_identity,
+            reset_request_tenant_token,
+            set_last_seen_token_fingerprint,
+        )
+
+        request_fingerprint = "kuudo-provider-derived-fingerprint"
+        request_token = bind_request_tenant_fingerprint(request_fingerprint)
+        set_last_seen_token_fingerprint(request_fingerprint)
+        auth_manager.provider = KuudoIdentityProvider(
+            [
+                Identity(id="id-a", type="kuudo", attributes={}),
+                Identity(id="id-b", type="kuudo", attributes={}),
+            ]
+        )
+
+        try:
+            await auth_manager.set_active_identity("id-b")
+
+            credentials = await auth_manager.get_active_credentials()
+
+            active_identity = get_active_identity()
+            assert active_identity is not None
+            assert active_identity.id == "id-b"
+            assert credentials.identity_id == "id-b"
+            assert auth_manager.provider.identity_credentials_calls == 1
+        finally:
+            reset_request_tenant_token(request_token)
 
     @pytest.mark.asyncio
     async def test_no_request_token_uses_provider_fallback_fingerprint(self, auth_manager):

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -562,6 +562,98 @@ class DummyContext:
 
 class TestSessionAwareCodeMode:
     @pytest.mark.asyncio
+    async def test_nested_call_tool_reconciles_bearer_swap_after_hydration(self):
+        from datetime import datetime, timedelta, timezone
+
+        from fastmcp.experimental.transforms import code_mode as fm_code_mode
+        from fastmcp.tools.base import ToolResult
+
+        from amazon_ads_mcp.auth.session_state import (
+            bind_request_tenant_fingerprint,
+            get_active_credentials,
+            get_active_identity,
+            get_active_profiles,
+            get_last_seen_token_fingerprint,
+            get_state_reset_reason,
+            reconcile_request_tenant_state,
+            reset_all_session_state,
+            reset_request_tenant_token,
+        )
+        from amazon_ads_mcp.middleware.auth_session_bridge import (
+            AUTH_SESSION_STATE_KEY,
+        )
+        from amazon_ads_mcp.models import AuthCredentials, Identity
+        from amazon_ads_mcp.server.code_mode import (
+            create_auth_bridging_sandbox_provider,
+        )
+
+        reset_all_session_state()
+        transform = fm_code_mode.CodeMode(
+            sandbox_provider=create_auth_bridging_sandbox_provider(ScriptedSandbox()),
+            discovery_tools=[],
+        )
+        transform.get_tool_catalog = AsyncMock(
+            return_value=[SimpleNamespace(name="page_profiles")]
+        )
+
+        async def fake_call_tool(name, params):
+            del name, params
+            identity = get_active_identity()
+            credentials = get_active_credentials()
+            return ToolResult(
+                structured_content={
+                    "identity_id": identity.id if identity else None,
+                    "credentials_identity_id": (
+                        credentials.identity_id if credentials else None
+                    ),
+                    "profiles": get_active_profiles(),
+                    "fingerprint": get_last_seen_token_fingerprint(),
+                    "state_reason": get_state_reset_reason(),
+                }
+            )
+
+        ctx = DummyContext(fastmcp=SimpleNamespace(call_tool=fake_call_tool))
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        ctx.state[AUTH_SESSION_STATE_KEY] = {
+            "active_identity": Identity(
+                id="tenant-a", type="kuudo", attributes={}
+            ).model_dump(mode="json"),
+            "active_credentials": AuthCredentials(
+                identity_id="tenant-a",
+                access_token="tenant-a-access-token",
+                expires_at=expires_at,
+                base_url="https://example.com",
+                headers={},
+            ).model_dump(mode="json"),
+            "active_profiles": {"tenant-a": "profile-a"},
+            "last_seen_token_fingerprint": "fingerprint-a",
+            "active_region": None,
+        }
+
+        request_token = bind_request_tenant_fingerprint("fingerprint-b")
+        try:
+            assert reconcile_request_tenant_state() is False
+            execute_tool = transform._get_execute_tool()
+            with patch("amazon_ads_mcp.server.code_mode.get_context", return_value=ctx):
+                result = await execute_tool.fn(
+                    code=json.dumps(
+                        {"ops": [{"tool": "page_profiles", "params": {}}]}
+                    ),
+                    ctx=ctx,
+                )
+
+            assert result == {
+                "identity_id": None,
+                "credentials_identity_id": None,
+                "profiles": {},
+                "fingerprint": "fingerprint-b",
+                "state_reason": "token_swapped",
+            }
+        finally:
+            reset_request_tenant_token(request_token)
+            reset_all_session_state()
+
+    @pytest.mark.asyncio
     async def test_nested_call_tool_persists_and_rehydrates_identity(self):
         from fastmcp.experimental.transforms import code_mode as fm_code_mode
         from fastmcp.tools.base import ToolResult

--- a/tests/unit/test_inbound_auth.py
+++ b/tests/unit/test_inbound_auth.py
@@ -291,3 +291,145 @@ async def test_inbound_middleware_scopes_kuudo_bearer_to_tool_call(monkeypatch):
     assert await middleware.on_call_tool(Context(), call_next) == "ok"
     with pytest.raises(KuudoConfigError):
         provider._get_effective_api_key()
+
+
+@pytest.mark.asyncio
+async def test_kuudo_bearer_swap_clears_persisted_tenant_state_before_tool_call(
+    monkeypatch,
+):
+    from datetime import datetime, timedelta, timezone
+
+    from amazon_ads_mcp.auth.session_state import (
+        get_active_credentials,
+        get_active_identity,
+        get_active_profiles,
+        get_last_seen_token_fingerprint,
+        get_state_reset_reason,
+        reset_all_session_state,
+        set_active_credentials,
+        set_active_identity,
+        set_active_profiles,
+    )
+    from amazon_ads_mcp.middleware.auth_session_bridge import AUTH_SESSION_STATE_KEY
+    from amazon_ads_mcp.middleware.authentication import AuthSessionStateMiddleware
+    from amazon_ads_mcp.models import AuthCredentials, Identity
+
+    monkeypatch.delenv("KUUDO_API_KEY", raising=False)
+    monkeypatch.delenv("MCP_INBOUND_TOKEN", raising=False)
+    reset_all_session_state()
+
+    provider = KuudoAmazonAdsProvider(
+        ProviderConfig(
+            base_url="https://app.kuudo.test",
+            provider="amazon_ads",
+        )
+    )
+    auth_manager = SimpleNamespace(
+        provider=provider,
+        get_active_region=lambda: "na",
+    )
+    inbound = create_inbound_http_auth_middleware(
+        auth_manager=auth_manager,
+        configured_host="0.0.0.0",
+    )
+    session_bridge = AuthSessionStateMiddleware()
+
+    class SessionContext:
+        def __init__(self):
+            self.request_context = SimpleNamespace(request=None)
+            self.state = {}
+
+        async def get_state(self, key):
+            return self.state.get(key)
+
+        async def set_state(self, key, value):
+            self.state[key] = value
+
+    session_context = SessionContext()
+
+    class Context:
+        method = "tools/call"
+        fastmcp_context = session_context
+
+    async def run_call(bearer, tool_call):
+        session_context.request_context.request = _request(
+            headers={"Authorization": f"Bearer {bearer}"}
+        )
+
+        async def call_session_bridge(context):
+            return await session_bridge.on_request(context, tool_call)
+
+        return await inbound.on_call_tool(Context(), call_session_bridge)
+
+    token_a = "sk_test_tenant_a"
+    token_b = "sk_test_tenant_b"
+
+    async def select_tenant_a(_context):
+        set_active_identity(
+            Identity(id="tenant-a-identity", type="kuudo", attributes={})
+        )
+        set_active_credentials(
+            AuthCredentials(
+                identity_id="tenant-a-identity",
+                access_token="tenant-a-access-token",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        set_active_profiles({"tenant-a-identity": "profile-a"})
+        return "selected"
+
+    try:
+        assert await run_call(token_a, select_tenant_a) == "selected"
+
+        persisted = session_context.state[AUTH_SESSION_STATE_KEY]
+        assert persisted["active_identity"]["id"] == "tenant-a-identity"
+        assert persisted[
+            "last_seen_token_fingerprint"
+        ] == provider.session_api_key_fingerprint(token_a)
+        assert persisted["last_seen_token_fingerprint"] != hashlib.sha256(
+            token_a.encode("utf-8")
+        ).hexdigest()
+
+        # FastMCP may dispatch the next request in a fresh async context.
+        reset_all_session_state()
+
+        async def execute_again_as_tenant_a(_context):
+            assert provider._get_effective_api_key() == token_a
+            assert get_active_identity().id == "tenant-a-identity"
+            assert get_active_credentials().access_token == "tenant-a-access-token"
+            assert get_active_profiles() == {"tenant-a-identity": "profile-a"}
+            assert (
+                get_last_seen_token_fingerprint()
+                == provider.session_api_key_fingerprint(token_a)
+            )
+            assert get_state_reset_reason() is None
+            return "preserved"
+
+        assert await run_call(token_a, execute_again_as_tenant_a) == "preserved"
+
+        reset_all_session_state()
+
+        async def execute_as_tenant_b(_context):
+            assert provider._get_effective_api_key() == token_b
+            assert get_active_identity() is None
+            assert get_active_credentials() is None
+            assert get_active_profiles() == {}
+            assert (
+                get_last_seen_token_fingerprint()
+                == provider.session_api_key_fingerprint(token_b)
+            )
+            assert get_state_reset_reason() == "token_swapped"
+            return "ok"
+
+        assert await run_call(token_b, execute_as_tenant_b) == "ok"
+        assert get_state_reset_reason() is None
+
+        persisted = session_context.state[AUTH_SESSION_STATE_KEY]
+        assert persisted["active_identity"] is None
+        assert persisted["active_credentials"] is None
+        assert persisted["active_profiles"] == {}
+        assert persisted[
+            "last_seen_token_fingerprint"
+        ] == provider.session_api_key_fingerprint(token_b)
+    finally:
+        reset_all_session_state()

--- a/tests/unit/test_inbound_auth.py
+++ b/tests/unit/test_inbound_auth.py
@@ -385,10 +385,7 @@ async def test_kuudo_bearer_swap_clears_persisted_tenant_state_before_tool_call(
         assert persisted["active_identity"]["id"] == "tenant-a-identity"
         assert persisted[
             "last_seen_token_fingerprint"
-        ] == provider.session_api_key_fingerprint(token_a)
-        assert persisted["last_seen_token_fingerprint"] != hashlib.sha256(
-            token_a.encode("utf-8")
-        ).hexdigest()
+        ] == await provider.session_api_key_fingerprint(token_a)
 
         # FastMCP may dispatch the next request in a fresh async context.
         reset_all_session_state()
@@ -400,7 +397,7 @@ async def test_kuudo_bearer_swap_clears_persisted_tenant_state_before_tool_call(
             assert get_active_profiles() == {"tenant-a-identity": "profile-a"}
             assert (
                 get_last_seen_token_fingerprint()
-                == provider.session_api_key_fingerprint(token_a)
+                == await provider.session_api_key_fingerprint(token_a)
             )
             assert get_state_reset_reason() is None
             return "preserved"
@@ -416,7 +413,7 @@ async def test_kuudo_bearer_swap_clears_persisted_tenant_state_before_tool_call(
             assert get_active_profiles() == {}
             assert (
                 get_last_seen_token_fingerprint()
-                == provider.session_api_key_fingerprint(token_b)
+                == await provider.session_api_key_fingerprint(token_b)
             )
             assert get_state_reset_reason() == "token_swapped"
             return "ok"
@@ -430,6 +427,6 @@ async def test_kuudo_bearer_swap_clears_persisted_tenant_state_before_tool_call(
         assert persisted["active_profiles"] == {}
         assert persisted[
             "last_seen_token_fingerprint"
-        ] == provider.session_api_key_fingerprint(token_b)
+        ] == await provider.session_api_key_fingerprint(token_b)
     finally:
         reset_all_session_state()

--- a/tests/unit/test_kuudo_provider.py
+++ b/tests/unit/test_kuudo_provider.py
@@ -297,7 +297,8 @@ def test_kuudo_fingerprint_is_stable_within_instance_and_scoped_between_instance
     assert first_fingerprint != second_provider._fingerprint("client-supplied-token")
 
 
-def test_kuudo_session_fingerprint_is_keyed_and_provider_local():
+@pytest.mark.asyncio
+async def test_kuudo_session_fingerprint_uses_provider_pbkdf2():
     config = ProviderConfig(
         base_url="https://app.kuudo.test",
         provider="amazon_ads",
@@ -306,11 +307,42 @@ def test_kuudo_session_fingerprint_is_keyed_and_provider_local():
     second_provider = KuudoAmazonAdsProvider(config)
     api_key = "client-supplied-token"
 
-    first_fingerprint = first_provider.session_api_key_fingerprint(api_key)
+    first_fingerprint = await first_provider.session_api_key_fingerprint(api_key)
 
-    assert first_fingerprint == first_provider.session_api_key_fingerprint(api_key)
-    assert first_fingerprint != second_provider.session_api_key_fingerprint(api_key)
-    assert first_fingerprint != hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+    assert first_fingerprint == first_provider._fingerprint(api_key)
+    assert first_fingerprint != await second_provider.session_api_key_fingerprint(
+        api_key
+    )
+
+
+@pytest.mark.asyncio
+async def test_bound_session_fingerprint_is_reused_by_provider_operations(monkeypatch):
+    provider = KuudoAmazonAdsProvider(
+        ProviderConfig(
+            base_url="https://app.kuudo.test",
+            provider="amazon_ads",
+        )
+    )
+    original_fingerprint = provider._fingerprint
+    fingerprint_calls: list[str] = []
+
+    def count_fingerprint(value: str) -> str:
+        fingerprint_calls.append(value)
+        return original_fingerprint(value)
+
+    monkeypatch.setattr(provider, "_fingerprint", count_fingerprint)
+    api_key = "client-supplied-token"
+    fingerprint = await provider.session_api_key_fingerprint(api_key)
+    api_key_token = provider.set_current_api_key(api_key)
+    fingerprint_token = provider.set_current_api_key_fingerprint(fingerprint)
+
+    try:
+        assert await provider._fingerprint_for(api_key) == fingerprint
+    finally:
+        provider.reset_current_api_key_fingerprint(fingerprint_token)
+        provider.reset_current_api_key(api_key_token)
+
+    assert fingerprint_calls == [api_key]
 
 
 def _kuudo_cache_miss_handler(request: httpx.Request) -> httpx.Response:

--- a/tests/unit/test_kuudo_provider.py
+++ b/tests/unit/test_kuudo_provider.py
@@ -297,6 +297,22 @@ def test_kuudo_fingerprint_is_stable_within_instance_and_scoped_between_instance
     assert first_fingerprint != second_provider._fingerprint("client-supplied-token")
 
 
+def test_kuudo_session_fingerprint_is_keyed_and_provider_local():
+    config = ProviderConfig(
+        base_url="https://app.kuudo.test",
+        provider="amazon_ads",
+    )
+    first_provider = KuudoAmazonAdsProvider(config)
+    second_provider = KuudoAmazonAdsProvider(config)
+    api_key = "client-supplied-token"
+
+    first_fingerprint = first_provider.session_api_key_fingerprint(api_key)
+
+    assert first_fingerprint == first_provider.session_api_key_fingerprint(api_key)
+    assert first_fingerprint != second_provider.session_api_key_fingerprint(api_key)
+    assert first_fingerprint != hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
 def _kuudo_cache_miss_handler(request: httpx.Request) -> httpx.Response:
     if request.url.path == "/api/auth/token-exchange":
         return httpx.Response(

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -10,12 +10,16 @@ import asyncio
 import pytest
 
 from amazon_ads_mcp.auth.session_state import (
+    bind_request_tenant_fingerprint,
     get_active_credentials,
     get_active_identity,
     get_active_profiles,
     get_last_seen_token_fingerprint,
     get_refresh_token_override,
+    get_state_reset_reason,
+    reconcile_request_tenant_state,
     reset_all_session_state,
+    reset_request_tenant_token,
     reset_session_state,
     set_active_credentials,
     set_active_identity,
@@ -281,3 +285,21 @@ class TestTokenFingerprint:
 
         assert get_last_seen_token_fingerprint() is None
         assert get_active_identity() is None
+
+    def test_unfingerprinted_tenant_state_is_cleared_before_binding(self):
+        reset_all_session_state()
+        set_active_identity(_make_identity("legacy-tenant"))
+        set_active_credentials(_make_credentials("legacy-tenant"))
+        set_active_profiles({"legacy-tenant": "profile-1"})
+        request_token = bind_request_tenant_fingerprint("new-tenant-fingerprint")
+
+        try:
+            assert reconcile_request_tenant_state() is True
+            assert get_active_identity() is None
+            assert get_active_credentials() is None
+            assert get_active_profiles() == {}
+            assert get_last_seen_token_fingerprint() == "new-tenant-fingerprint"
+            assert get_state_reset_reason() == "token_swapped"
+        finally:
+            reset_request_tenant_token(request_token)
+            reset_all_session_state()


### PR DESCRIPTION
## Summary

- bind each Kuudo bearer to persisted MCP tenant state with a provider-local fingerprint
- clear active identity, credentials, and profiles before tool execution when the bearer changes
- derive the discriminator with the existing salted 600,000-iteration PBKDF2 implementation
- reuse the derived fingerprint across nested middleware and provider operations within one request

## Root cause

The inbound Kuudo middleware scoped the current API key for downstream provider calls, but the session bridge could hydrate identity and credentials selected under a previous bearer. The initial keyed HMAC discriminator fixed ownership tracking but triggered the repository's sensitive-data CodeQL policy.

## Validation

- uv sync
- uv run ruff check --fix
- uv run pytest -q tests/unit/test_kuudo_provider.py tests/unit/test_inbound_auth.py tests/unit/test_authentication_middleware.py tests/unit/test_auth_session_bridge.py tests/unit/test_session_state.py tests/unit/test_session_scope_signaling.py

Result: 117 passed.